### PR TITLE
Only define dtop once

### DIFF
--- a/jquery.fullPage.js
+++ b/jquery.fullPage.js
@@ -325,8 +325,10 @@
 		};
 
 		function scrollPage(element) {
-			var scrollOptions = {}, dtop, scrolledElement;
-			
+			var scrollOptions = {}, scrolledElement;
+			var dest = element.position();
+			var dtop = dest !== null ? dest.top : null;
+
 			//preventing from activating the MouseWheelHandler event
 			//more than once if the page is scrolling
 			isMoving = true;
@@ -336,9 +338,6 @@
 			}else{
 				location.hash = '';
 			}
-			
-			var dest = element.position();
-			var dtop = dest !== null ? dest.top : null;
 	
 			if(options.autoScrolling){
 			


### PR DESCRIPTION
`dtop` was unnecessarily defined twice.

I have also moved the variable definitions up on the top of the `function` since these don't rely on anything else happening before they are assigned.
