### PR TITLE
Adding Windows Phone to user agent match list

### DIFF
--- a/jquery.fullPage.js
+++ b/jquery.fullPage.js
@@ -54,7 +54,7 @@
 		//flag to avoid very fast sliding for landscape sliders
 		var slideLapse = true;
 
-		var isTablet = navigator.userAgent.match(/(iPhone|iPod|iPad|Android|BlackBerry)/);
+		var isTablet = navigator.userAgent.match(/(iPhone|iPod|iPad|Android|BlackBerry|Windows Phone)/);
 
 		var windowsHeight = $(window).height();
 		var isMoving = false;


### PR DESCRIPTION
I noticed that Windows Phone was missing from the list of user agent's to match for deducing if dealing with a tablet, so I've added it.
