### PR TITLE
replace next and prev in moveSlideDown and moveSlideUp functions with nextAll and prevAll

### DIFF
--- a/jquery.fullPage.js
+++ b/jquery.fullPage.js
@@ -431,7 +431,7 @@
 		}
 		
 		$.fn.fullpage.moveSlideUp = function(){
-			var prev = $('.section.active').prev('.section');
+			var prev = $('.section.active').prevAll('.section');
 			
 			//looping to the bottom if there's no more sections above
 			if(options.loopTop && !prev.length){
@@ -444,7 +444,7 @@
 		};
 
 		$.fn.fullpage.moveSlideDown = function (){
-			var next = $('.section.active').next('.section');
+			var next = $('.section.active').nextAll('.section');
 			
 			//looping to the top if there's no more sections below
 			if(options.loopBottom && !next.length){


### PR DESCRIPTION
If you have other content between fullpage sections, that is not fullpage, the moveSlideDown or moveSlideUp functions will not jump to the next/previous section. This can be fixed by changing prev/next to prevAll/nextAll.
