### PR TITLE
Fix .top being called on undefined

### DIFF
--- a/jquery.fullPage.js
+++ b/jquery.fullPage.js
@@ -598,7 +598,7 @@
 
 				// Recalculate animation variables
 				dest = element.position();
-				dtop = dest !== null ? dest.top : null;
+				dtop = dest !== undefined ? dest.top : null;
 				yMovement = getYmovement(element);
 			}
 


### PR DESCRIPTION
This pull request fixes an issue where `dest.top` was being called even when `dest` was undefined. 
