### PR TITLE
getXmovement can now return "none"

### DIFF
--- a/jquery.fullPage.js
+++ b/jquery.fullPage.js
@@ -1086,7 +1086,10 @@
 		* Retuns `right` or `left` depending on the scrolling movement to reach its destination
 		* from the current slide.
 		*/
-		function getXmovement(fromIndex, toIndex){			
+		function getXmovement(fromIndex, toIndex){
+			if( fromIndex == toIndex){
+				return 'none'
+			}
 			if(fromIndex > toIndex){
 				return 'left';
 			}


### PR DESCRIPTION
if called without real movement- i.e. user clicks a link to a slide that they are already on.
