### PR TITLE
Fixes placement error of long horizontal navs on small screens

### DIFF
--- a/jquery.fullPage.css
+++ b/jquery.fullPage.css
@@ -100,6 +100,7 @@ html, body {
     z-index: 4;
     left: 50%;
     opacity: 1;
+    white-space: nowrap;
 }
 .fullPage-slidesNav.bottom {
     bottom: 17px;


### PR DESCRIPTION
On small screens like iPhones, the navigation would break, and the function for calculating margin for the nav would get the wrong result, thus placing it wrong. Simple fix.
