### PR TITLE
Add option for showing controlArrow on horizontal slides

### DIFF
--- a/jquery.fullPage.js
+++ b/jquery.fullPage.js
@@ -409,13 +409,13 @@
 					if (activeSection.find('.slides').length && Math.abs(touchStartX - touchEndX) > (Math.abs(touchStartY - touchEndY))) {
 					    
 					    //is the movement greater than the minimum resistance to scroll?
-					    if (Math.abs(touchStartX - touchEndX) > ($(window).width() / 100 * options.touchSensitivity)) {
-					        if (touchStartX > touchEndX) {
-                                $.fn.fullpage.moveSlideLeft();
-                            } else {
-                                $.fn.fullpage.moveSlideRight();
-                            }
-                        }
+					    	if (Math.abs(touchStartX - touchEndX) > ($(window).width() / 100 * options.touchSensitivity)) {
+					        	if (touchStartX > touchEndX) {
+                                				$.fn.fullpage.moveSlideRight();
+                            				} else {
+                                				$.fn.fullpage.moveSlideLeft();
+                            				}
+                        			}
 					}
 
 					//vertical scrolling
@@ -763,10 +763,10 @@
 
 				//left
 				case 37:
-                    $.fn.fullpage.moveSlideLeft();
-                    break;
+                    			$.fn.fullpage.moveSlideLeft();
+                    			break;
 
-                    //right
+                    		//right
 				case 39:
 					$.fn.fullpage.moveSlideRight();
 					break;
@@ -808,64 +808,57 @@
 		
 		$.fn.fullpage.moveSlideRight = function() {
             		moveSlide('next');
-        }
+	        }
+	
+	        $.fn.fullpage.moveSlideLeft = function () {
+	            	moveSlide('prev');
+	        }
+	
+	        function moveSlide(direction) {
+	            // check direction, presence of >1 slide and whether slide is currently moving
 
-        $.fn.fullpage.moveSlideLeft = function () {
-            moveSlide('prev');
-        }
-
-        function moveSlide(direction) {
-            // direction is mandatory
-            if (!direction) {
-                return;
-            }
-
-            var activeSection = $('.section.active');
-            var slides = activeSection.find('.slides');
-
-            // break if no slides on this page
-            if (!slides.length) {
-                return;
-            }
-            var currentSlide = slides.find('.slide.active');
-            var destiny = null;
-
-            if (direction === 'prev') {
-                destiny = currentSlide.prev('.slide');
-            } else {
-                destiny = currentSlide.next('.slide');
-            }
-
-            //is there isn't a next slide in the secuence?
-            if (!destiny.length) {
-                //respect loopHorizontal setting
-                if (!options.loopHorizontal) return;
-                //to the last
-                if (direction === 'prev') {
-                    destiny = currentSlide.siblings(':last');
-                } else {
-                    destiny = currentSlide.siblings(':first');
-                }
-            }
-
-            //not that fast my friend! :)
-            if (slideMoving) {
-                return;
-            }
-            slideMoving = true;
-
-            landscapeScroll(slides, destiny);
-        }
+	
+	            var activeSection = $('.section.active');
+	            var slides = activeSection.find('.slides');
+	
+	            if (!direction || !slides.length || slideMoving) {
+	                return;
+	            }
+	            
+	            var currentSlide = slides.find('.slide.active');
+	            var destiny = null;
+	
+	            if (direction === 'prev') {
+	                destiny = currentSlide.prev('.slide');
+	            } else {
+	                destiny = currentSlide.next('.slide');
+	            }
+	
+	            //is there isn't a next slide in the secuence?
+	            if (!destiny.length) {
+	                //respect loopHorizontal setting
+	                if (!options.loopHorizontal) return;
+	                //to the last
+	                if (direction === 'prev') {
+	                    destiny = currentSlide.siblings(':last');
+	                } else {
+	                    destiny = currentSlide.siblings(':first');
+	                }
+	            }
+	
+	            slideMoving = true;
+	            landscapeScroll(slides, destiny);
+	        }
 
         /**
          * Scrolling horizontally when clicking on the slider controls.
 		 */
 		$('.section').on('click', '.controlArrow', function() {
 			if ($(this).hasClass('prev')) {
-                $.fn.fullpage.moveSlideLeft();
-            } else {
-                $.fn.fullpage.moveSlideRight();
-            }
+                		$.fn.fullpage.moveSlideLeft();
+	         	} else {
+                		$.fn.fullpage.moveSlideRight();
+            		}
 		});
 
 		


### PR DESCRIPTION
Added option, default behaviour is still to show the arrows. Since keyboard navigation depended on simulating clicks on the controlArrows (why?), created new (wrapper) methods for moving left and right, and a function doing the actual work, mostly copied from the controlArrow onClick behaviour, with some extra steps and checks.

Please note that I'm a novice/hobby coder, so I'm bound to have mode some style errors at the least. I do feel that keyboard navigation should not depend on the arrows being there (and visible), and that there should be an easy way of not having arrows.
