### PR TITLE
Add mouseWheelTimeout option

### DIFF
--- a/jquery.fullPage.js
+++ b/jquery.fullPage.js
@@ -530,7 +530,7 @@
 					lastMouseWheelTimeStamp = currentMouseWheelTimeStamp;
 				}
 
-                var delta = Math.max(-1, Math.min(1,
+				var delta = Math.max(-1, Math.min(1,
 						(e.wheelDelta || -e.deltaY || -e.detail)));
 				var scrollable;
 				var activeSection = $('.section.active');


### PR DESCRIPTION
Hello!

On some touchpads (and maybe with normal mouses) when user scrolls a lot, plugin scrolls slides twice.

I've added a 'mouseWheelTimeout' option so you can add some kind of 'debouncing' to MouseWheelHandler.

It works for me with value 700.
