### PR TITLE
renamed bower dependency "jQuery" => "jquery"; added bower_components to...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+bower_components/

--- a/bower.json
+++ b/bower.json
@@ -27,6 +27,6 @@
   ],
   "dependencies": {
       "jquery.slimscroll": "latest",
-      "jQuery": "latest"
+      "jquery": "latest"
     }
 }


### PR DESCRIPTION
the bower.json file in the downloaded package states "jquery" as the name.
it is important because it impacts scripts with further libs depending on "jquery" .
e.g. when automatically generating sources => jquery gets injected twice.

``` html
<!-- build:js scripts/vendor.js -->
<!-- bower:js -->
<script src="bower_components/jquery/dist/jquery.js"></script>
<script src="bower_components/jQuery/dist/jquery.js"></script>
<!-- endbower -->
<!-- endbuild -->
```
