### PR TITLE
Update to line 139 (jquery.fullPage.css)

### DIFF
--- a/jquery.fullPage.css
+++ b/jquery.fullPage.css
@@ -136,7 +136,7 @@ html, body {
     text-decoration: none;
 }
 #fp-nav li .active span,
-.fp-slidesNav.active span {
+.fp-slidesNav .active span {
     background: #333;
 }
 #fp-nav span,


### PR DESCRIPTION
Original : .fp-slidesNav.active span
Update : .fp-slidesNav .active span

Reason: slidesNavigation css could not have the active class because of the space issue.
