### PR TITLE
Fix navigationTooltips (fullPage-tooltip) to allow multiple words.

### DIFF
--- a/jquery.fullPage.css
+++ b/jquery.fullPage.css
@@ -163,6 +163,7 @@ html, body {
     font-size: 14px;
     font-family: arial, helvetica, sans-serif;
     top: -2px;
+    white-space: nowrap;
 }
 .fp-tooltip.right {
     right: 20px;


### PR DESCRIPTION
When word length is more than 1 word, the text field would be forced to break. This fix allows navigationTooltips to stay on the same line (with no line breaks). 
