### PR TITLE
suggestion: add background-color to v-navigation tooltip

### DIFF
--- a/jquery.fullPage.css
+++ b/jquery.fullPage.css
@@ -155,8 +155,12 @@ html, body {
 }
 .fp-tooltip {
     position: absolute;
-    top: -2px;
+    top: -5px;
+ 		padding: 0.3em 0.9em 0.3em 0.6em;
+		border-radius: 0px 1em 1em 0px;
     color: #fff;
+		background: #111; /* IE<=8 */
+		background-color: rgba(17, 17, 17, 0.75);
     font-size: 14px;
     font-family: arial, helvetica, sans-serif;
     white-space: nowrap;


### PR DESCRIPTION
So the popup may be seen over similar-color elements.  Also is a subtitle pointer.
Before, the tooltip may be hidden by the arrows & text:
![idea-fullpage-tooltip_no_background](https://cloud.githubusercontent.com/assets/1308419/3674753/4889bfe8-1279-11e4-9c82-ee62f2e5c91f.png)
Now it the popup text is easily seen, even with image backgrounds:
![idea-fullpage-tooltip_background](https://cloud.githubusercontent.com/assets/1308419/3674762/61c9d2fe-1279-11e4-8c8f-e0b025a417e8.png)
![idea-fullpage-tooltip_image_background](https://cloud.githubusercontent.com/assets/1308419/3674769/66d213f6-1279-11e4-82ab-1e6b5ac78677.jpg)
