### PR TITLE
Fix oversize font when width<900 and height<825

### DIFF
--- a/jquery.fullPage.js
+++ b/jquery.fullPage.js
@@ -1,5 +1,5 @@
 /**
- * fullPage 2.2.2
+ * fullPage 2.2.3
  * https://github.com/alvarotrigo/fullPage.js
  * MIT licensed
  *

--- a/jquery.fullPage.min.js
+++ b/jquery.fullPage.min.js
@@ -1,5 +1,5 @@
 /**
- * fullPage 2.2.2
+ * fullPage 2.2.3
  * https://github.com/alvarotrigo/fullPage.js
  * MIT licensed
  *


### PR DESCRIPTION
The preferred window size is 900x825. The font size is scaled down when
the actual width or height are smaller. If both are smaller, the width
percentage is always used. This causes problems, for instance a 900x768
window has fonts that fit (sized with the height scale), but resizing it
down to 899x768 switches to use the width scale and the font gets bigger
again, overflowing off the page.

The fix is to calculate both scales and take the minimum to ensure that
the content fits in both dimensions.
