### PR TITLE
Fixed navigation tooltips not fading out correctly

### DIFF
--- a/jquery.fullPage.js
+++ b/jquery.fullPage.js
@@ -921,7 +921,9 @@
 				$('<div class="fp-tooltip ' + options.navigationPosition +'">' + tooltip + '</div>').hide().appendTo($(this)).fadeIn(200);
 			},
 			mouseleave: function(){
-				$(this).find('.fp-tooltip').fadeOut().remove();
+				$(this).find('.fp-tooltip').fadeOut(200, function() {
+					$(this).remove();
+				});
 			}
 		}, '#fp-nav li');
 


### PR DESCRIPTION
remove() can't be chained to an animation. It will get removed before the animation has ended. This fixes this by waiting for the animation to finish before removing the element
