### PR TITLE
Ignore examples/ for Bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,8 @@
     "node_modules",
     "bower_components",
     "test",
-    "tests"
+    "tests",
+    "examples"
   ],
   "dependencies": {
       "jquery.slimscroll": "latest",


### PR DESCRIPTION
I do not see how examples/ is useful for bower, especially for those who have a low download
