### PR TITLE
Fix SlimScrolling handler for AJAX scenarios.

### DIFF
--- a/jquery.fullPage.js
+++ b/jquery.fullPage.js
@@ -1642,9 +1642,6 @@
 
 			//scrolling the page to the top with no animation
 			$('html, body').scrollTop(0);
-
-			//to know if the plugin was already used in case it is used in a future again
-			container.addClass('fullpage-used');
 		}
 
 	};


### PR DESCRIPTION
If fullpage is invocated way after the window is loaded (e. g. when a page that is fullPaged is dynamically added to DOM) createSlimScrollingHandler() is never run.
To fix this I propose checking for document.readyState, not whether fullPage.js is already loaded.
