### PR TITLE
Fixed issue with fitSections and multiple callbacks to onLeave

### DIFF
--- a/jquery.fullPage.js
+++ b/jquery.fullPage.js
@@ -885,7 +885,7 @@
 			}
 
 			//callback (onLeave) if the site is not just resizing and readjusting the slides
-			$.isFunction(options.onLeave) && !localIsResizing && options.onLeave.call(this, leavingSection, (sectionIndex + 1), yMovement);
+			$.isFunction(options.onLeave) && !localIsResizing && !options.fitSection && options.onLeave.call(this, leavingSection, (sectionIndex + 1), yMovement);
 
 			// Use CSS3 translate functionality or...
 			if (options.css3 && options.autoScrolling) {


### PR DESCRIPTION
When fitSections was enabled, onLeave was firing multiple times. Since onLeave already fires during normal scroll, it's not needed again after scrollPage is run.
