### PR TITLE
Added onEnd option/callback and event dispatchers

### DIFF
--- a/jquery.fullPage.js
+++ b/jquery.fullPage.js
@@ -56,6 +56,7 @@
 
 
 			//events
+			'onEnd': null,
 			'afterLoad': null,
 			'onLeave': null,
 			'afterRender': null,
@@ -162,6 +163,9 @@
 
 			if (prev.length) {
 				scrollPage(prev, null, true);
+			} else {
+				// dispatch event that you have reached the end
+				$.isFunction( options.onEnd ) && options.onEnd.call( this, "top");				
 			}
 		};
 
@@ -176,6 +180,9 @@
 
 			if(next.length){
 				scrollPage(next, null, false);
+			} else {
+				// dispatch event that you have reached the end
+				$.isFunction( options.onEnd ) && options.onEnd.call( this, "bottom");
 			}
 		};
 


### PR DESCRIPTION
Allows for a new callback function to dispatch “top” or “bottom” when continuous scroll is off, so a UI can react or indicate a user has reached the last item in the top or bottom of an overall stack of sections.
