### PR TITLE
Fix for autoScroll on Windows Phone 8.1 IE 11 devices

### DIFF
--- a/jquery.fullPage.js
+++ b/jquery.fullPage.js
@@ -266,7 +266,7 @@
 		var slideMoving = false;
 
 		var isTouchDevice = navigator.userAgent.match(/(iPhone|iPod|iPad|Android|BlackBerry|BB10|Windows Phone|Tizen|Bada)/);
-		var isTouch = (('ontouchstart' in window) || (navigator.msMaxTouchPoints > 0));
+		var isTouch = (('ontouchstart' in window) || (navigator.msMaxTouchPoints > 0) || (navigator.maxTouchPoints));
 		var container = $(this);
 		var windowsHeight = $(window).height();
 		var isMoving = false;


### PR DESCRIPTION
May address #670  but it fixed my ability to use AutoScroll on my Windows phone 8.1 IE 11 Mobile device.
