### PR TITLE
Fix padding-top and padding-bottom 0px values for IE9 and in some cases for IE8

### DIFF
--- a/jquery.fullPage.js
+++ b/jquery.fullPage.js
@@ -1413,13 +1413,15 @@
 			var sectionHeight = windowsHeight;
 
 			if(options.paddingTop || options.paddingBottom){
-				var section = element;
+				var section = element,
+				sectionTop = section.css('padding-top') === '0px' ? options.paddingTop : section.css('padding-top'),
+				sectionBottom = section.css('padding-bottom') === '0px' ? options.paddingBottom : section.css('padding-bottom');
+
 				if(!section.hasClass('fp-section')){
 					section = element.closest('.fp-section');
 				}
 
-				var paddings = parseInt(section.css('padding-top')) + parseInt(section.css('padding-bottom'));
-				sectionHeight = (windowsHeight - paddings);
+				sectionHeight = (windowsHeight - (parseInt(sectionTop) + parseInt(sectionBottom)));
 			}
 
 			return sectionHeight;


### PR DESCRIPTION
It happend various times that padding-top and padding-bottom on the section where '0px' and the height of the section wasn't correct. If this is the case, it's fine to use the global configuration for padding-top/padding-bottom.

Edit: ignore the first two commits, rebasing was going wrong, but the end result is good.
