### PR TITLE
avoid TypeError

### DIFF
--- a/jquery.fullPage.js
+++ b/jquery.fullPage.js
@@ -118,7 +118,9 @@
 				silentScroll(0);
 
 				//scrolling the page to the section with no animation
-				$('html, body').scrollTop(element.position().top);
+				if (element.length) {
+					$('html, body').scrollTop(element.position().top);
+				}
 			}
 
 		};


### PR DESCRIPTION
We're getting a type error "Cannot read property 'top' of undefined" - I'm adding a condition to check if an element exists before calling position().  Note, this is already done above within the method [here](https://github.com/alvarotrigo/fullPage.js/blob/master/jquery.fullPage.js#L99).

Error occurs when destroy('all') is called.