### PR TITLE
Fix setBodyClass method

### DIFF
--- a/jquery.fullPage.js
+++ b/jquery.fullPage.js
@@ -1876,10 +1876,11 @@
             text = text.replace('/', '-').replace('#','');
 
             //removing previous anchor classes
-            $body[0].className = $body[0].className.replace(/\b\s?fp-viewing-[^\s]+\b/g, '');
+            var classRe = new RegExp('\\b\\s?' + VIEWING_PREFIX + '-[^\\s]+\\b', "g");
+            $body[0].className = $body[0].className.replace(classRe, '');
 
             //adding the current anchor
-            $body.addClass(VIEWING_PREFIX + text);
+            $body.addClass(VIEWING_PREFIX + '-' + text);
         }
 
         /**


### PR DESCRIPTION
When I updated fullPage.js I noticed that the body class had changed to `fp-viewing0` instead of `fp-viewing-0` (this started happening in rev 9702c05). Added the dash back in.

Also updated the regexp that cleans the body classes to use the constant `VIEWING_PREFIX`.

Thanks for this awesome script! Keep up the good work :+1: 