### PR TITLE
Explicit padding-top/bottom inline styles

### DIFF
--- a/jquery.fullPage.js
+++ b/jquery.fullPage.js
@@ -430,8 +430,12 @@
 
             $(this).css('height', windowsHeight + 'px');
 
-            if(options.paddingTop || options.paddingBottom){
-                $(this).css('padding', options.paddingTop  + ' 0 ' + options.paddingBottom + ' 0');
+            if(options.paddingTop){
+                $(this).css('padding-top', options.paddingTop);
+            }
+            
+            if(options.paddingBottom){
+                $(this).css('padding-bottom', options.paddingBottom);
             }
 
             if (typeof options.sectionsColor[index] !==  'undefined') {


### PR DESCRIPTION
Only apply top and bottom padding values so not to overwrite existing left/right padding values of the section element.