### PR TITLE
Fixes Chrome vertical height issue.

### DIFF
--- a/jquery.fullPage.js
+++ b/jquery.fullPage.js
@@ -342,7 +342,7 @@
 
                 //adjusting the height of the table-cell for IE and Firefox
                 if(options.verticalCentered){
-                    $(this).find(TABLE_CELL_SEL).css('height', getTableHeight($(this)) + 'px');
+                    $(this).find(TABLE_CELL_SEL).css('height', '100%');
                 }
 
                 $(this).css('height', '100%');

--- a/jquery.fullPage.js
+++ b/jquery.fullPage.js
@@ -345,7 +345,7 @@
                     $(this).find(TABLE_CELL_SEL).css('height', getTableHeight($(this)) + 'px');
                 }
 
-                $(this).css('height', windowsHeight + 'px');
+                $(this).css('height', '100%');
 
                 //resizing the scrolling divs
                 if(options.scrollOverflow){


### PR DESCRIPTION
Seems to fix issue relating to Chrome's inability to pull correct height. Haven't tested within other browsers.

Before:
![Before](http://i.imgur.com/ZJ1Rfxc.jpg)

After:
![After](http://i.imgur.com/ieUxsez.png)