### PR TITLE
window.event can actually refer to an HTML element

### DIFF
--- a/jquery.fullPage.js
+++ b/jquery.fullPage.js
@@ -1038,7 +1038,7 @@
             //autoscrolling and not zooming?
             if(options.autoScrolling && !controlPressed){
                 // cross-browser wheel delta
-                e = window.event || e;
+                e = e || window.event;
                 var value = e.wheelDelta || -e.deltaY || -e.detail;
                 var delta = Math.max(-1, Math.min(1, value));
 

--- a/jquery.fullPage.js
+++ b/jquery.fullPage.js
@@ -1042,7 +1042,7 @@
                 var value = e.wheelDelta || -e.deltaY || -e.detail;
                 var delta = Math.max(-1, Math.min(1, value));
 
-                //Limiting the array to 150 (lets not waist memory!)
+                //Limiting the array to 150 (lets not waste memory!)
                 if(scrollings.length > 149){
                     scrollings.shift();
                 }


### PR DESCRIPTION
... in Firefox.  Code defensively against this.

This fix tested in Firefox & Chrome, but not IE.