### PR TITLE
fixes issue where background video controls were visible

### DIFF
--- a/examples/backgroundVideo.html
+++ b/examples/backgroundVideo.html
@@ -131,7 +131,7 @@
 
 <div id="fullpage">
 	<div class="section " id="section0">
-		<video autoplay loop muted controls="false" id="myVideo">
+		<video autoplay loop muted id="myVideo">
 			<source src="imgs/flowers.mp4" type="video/mp4">
 			<source src="imgs/flowers.webm" type="video/webm">
 		</video>


### PR DESCRIPTION
Only omission of `controls` attribute will hide background video controls.

`controls="false"` does nothing.