### PR TITLE
Pass down container to call of `afterRender`

### DIFF
--- a/jquery.fullPage.js
+++ b/jquery.fullPage.js
@@ -740,7 +740,7 @@
             playMedia(section);
 
             $.isFunction( options.afterLoad ) && options.afterLoad.call(section, section.data('anchor'), (section.index(SECTION_SEL) + 1));
-            $.isFunction( options.afterRender ) && options.afterRender.call( this);
+            $.isFunction( options.afterRender ) && options.afterRender.call(container);
         }
 
 


### PR DESCRIPTION
`this` is the `window` object currently, although the documentation
states that it should be the plugin container.