### PR TITLE
"location.hash = the-hash" not working in Android 4.0.3

### DIFF
--- a/jquery.fullPage.js
+++ b/jquery.fullPage.js
@@ -2078,7 +2078,7 @@
         */
         function setUrlHash(url){
             if(options.recordHistory){
-                location.hash = url;
+                location.href = '#' + url;
             }else{
                 //Mobile Chrome doesn't work the normal way, so... lets use HTML5 for phones :)
                 if(isTouchDevice || isTouch){


### PR DESCRIPTION
This glitch will cause the URL remains unchanged after the user slid the page, and back button not working as usual. But strangely it works on Android 2.3.3
This answer seems related: http://stackoverflow.com/a/6975488/1745885