### PR TITLE
A little trouble when using fullPage.js with AMD (Require.js)

### DIFF
--- a/jquery.fullPage.js
+++ b/jquery.fullPage.js
@@ -659,10 +659,11 @@
             //setting the class for the body element
             setBodyClass();
 
-            $window.on('load', function() {
+            if (document.readyState != "complete") {
+                $window.on('load', scrollToAnchor);
+            } else {
                 scrollToAnchor();
-            });
-
+            }
         });
 
 


### PR DESCRIPTION
When i use fullpage.js with require.js window.load event triggers before fullpage has registered handler for scrollToAnchor. So i resolved this issue by checking for document.readyState, and it is helps.