### PR TITLE
set a general offset variable

### DIFF
--- a/jquery.fullPage.js
+++ b/jquery.fullPage.js
@@ -124,6 +124,7 @@
             scrollOverflow: false,
             touchSensitivity: 5,
             normalScrollElementTouchThreshold: 5,
+            topOffset: 0,
 
             //Accessibility
             keyboardScrolling: true,
@@ -243,6 +244,13 @@
         */
         FP.setLockAnchors = function(value){
             options.lockAnchors = value;
+        };
+
+        /**
+        * Sets topOffset variable
+        */
+        FP.setTopOffset = function(value){
+            options.topOffset = value;
         };
 
         /**
@@ -1202,7 +1210,7 @@
                 if(typeof dest === 'undefined'){ return; } //there's no element to scroll, leaving the function
 
                 //auto height? Scrolling only a bit, the next element's height. Otherwise the whole viewport.
-                var dtop = element.hasClass(AUTO_HEIGHT) ? (dest.top - windowsHeight + element.height()) : dest.top;
+                var dtop = element.hasClass(AUTO_HEIGHT) ? ( dest.top - windowsHeight + element.height() + options.topOffset ) : ( dest.top + options.topOffset );
 
                 //local variables
                 var v = {


### PR DESCRIPTION
This offset variable is useful when fullPage.js is wrapped into a bigger website, with an existing header is shifting all the scroll positions.