### PR TITLE
Allow Custom Slides Nav Element

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ $('#fullpage').fullpage({
 
 - `showActiveTooltip`: (default `false`) Shows a persistent tooltip for the actively viewed section in the vertical navigation.
 
-- `slidesNavigation`: (default `false`) If set to `true` it will show a navigation bar made up of small circles for each landscape slider on the site.
+- `slidesNavigation`: (default `false`) If set to `true` it will show a navigation bar made up of small circles for each landscape slider on the site. You can use custom slides navigation markup by creating an element with the class name `.fp-slidesNav` inside any given section.
 
 - `slidesNavPosition`: (default `bottom`) Defines the position for the landscape navigation bar for sliders. Admits `top` and `bottom` as values. You may want to modify the CSS styles to determine the distance from the top or bottom as well as any other style such as color.
 

--- a/jquery.fullPage.js
+++ b/jquery.fullPage.js
@@ -2073,22 +2073,22 @@
         * Creates a landscape navigation bar with dots for horizontal sliders.
         */
         function addSlidesNavigation(section, numSlides){
-            if (section.find(SLIDES_NAV_SEL).length == 0) {
-                section.append('<div class="' + SLIDES_NAV + '"><ul></ul></div>');
-            }
             var nav = section.find(SLIDES_NAV_SEL);
+            if (nav.length == 0) {
+                nav = section.append('<div class="' + SLIDES_NAV + '"><ul></ul></div>');
+                            
+                //top or bottom
+                nav.addClass(options.slidesNavPosition);
 
-            //top or bottom
-            nav.addClass(options.slidesNavPosition);
+                for(var i=0; i< numSlides; i++){
+                    nav.find('ul').append('<li><a href="#"><span></span></a></li>');
+                }
 
-            for(var i=0; i< numSlides; i++){
-                nav.find('ul').append('<li><a href="#"><span></span></a></li>');
+                //centering it
+                nav.css('margin-left', '-' + (nav.width()/2) + 'px');
+
+                nav.find('li').first().find('a').addClass(ACTIVE);
             }
-
-            //centering it
-            nav.css('margin-left', '-' + (nav.width()/2) + 'px');
-
-            nav.find('li').first().find('a').addClass(ACTIVE);
         }
 
 

--- a/jquery.fullPage.js
+++ b/jquery.fullPage.js
@@ -2073,7 +2073,9 @@
         * Creates a landscape navigation bar with dots for horizontal sliders.
         */
         function addSlidesNavigation(section, numSlides){
-            section.append('<div class="' + SLIDES_NAV + '"><ul></ul></div>');
+            if (section.find(SLIDES_NAV_SEL).length == 0) {
+                section.append('<div class="' + SLIDES_NAV + '"><ul></ul></div>');
+            }
             var nav = section.find(SLIDES_NAV_SEL);
 
             //top or bottom


### PR DESCRIPTION
This allows someone to create custom slides nav markup by manually inserting an element with the class .fp-slidesNav in the section by looking for an existing .fp-slidesNav before appending the default.