### PR TITLE
Fixed the vertical resizing issue caused by async.

### DIFF
--- a/examples/simple.html
+++ b/examples/simple.html
@@ -21,7 +21,8 @@
 	<script type="text/javascript">
 		$(document).ready(function() {
 			$('#fullpage').fullpage({
-				sectionsColor: ['#f2f2f2', '#4BBFC3', '#7BAABE', 'whitesmoke', '#ccddff']
+				sectionsColor: ['#f2f2f2', '#4BBFC3', '#7BAABE', 'whitesmoke', '#ccddff'],
+				css3: false
 			});
 		});
 	</script>

--- a/jquery.fullPage.js
+++ b/jquery.fullPage.js
@@ -1196,10 +1196,13 @@
         * Scrolls the site to the given element and scrolls to the slide if a callback is given.
         */
         function scrollPage(element, callback, isMovementUp){
-            //requestAnimFrame is used in order to prevent a Chrome 44 bug (http://stackoverflow.com/a/31961816/1081396)
-            requestAnimFrame(function(){
+            //Local Variables need to be cached outside of the requestAnimFrame or they will not be set until a later point
+            //at which they may be different.
+            
                 var dest = element.position();
-                if(typeof dest === 'undefined'){ return; } //there's no element to scroll, leaving the function
+
+                //there's no element to scroll, leaving the function
+                if(typeof dest === 'undefined'){ return; }
 
                 //auto height? Scrolling only a bit, the next element's height. Otherwise the whole viewport.
                 var dtop = element.hasClass(AUTO_HEIGHT) ? (dest.top - windowsHeight + element.height()) : dest.top;
@@ -1223,8 +1226,12 @@
                     localIsResizing: isResizing
                 };
 
-                //quiting when destination scroll is the same as the current one
-                if((v.activeSection.is(element) && !isResizing) || (options.scrollBar && $window.scrollTop() === v.dtop)){ return; }
+            //requestAnimFrame is used in order to prevent a Chrome 44 bug (http://stackoverflow.com/a/31961816/1081396)
+            requestAnimFrame(function(){
+
+                //quiting when destination scroll is the same as the current one 
+                //Note: must check localIsResizing as the isResizing var may change by the time this is run.
+                if((v.activeSection.is(element) && !v.localIsResizing) || (options.scrollBar && $window.scrollTop() === v.dtop)){ return; }
 
                 if(v.activeSlide.length){
                     var slideAnchorLink = v.activeSlide.data('anchor');


### PR DESCRIPTION
This is a fix for issue #1442 

Moved the local variable cache assignment out of `requestAnimationFrame` to avoid them being overwritten before being saved.

Also changed `!isResizing` to `!v.localIsResizing` in first check inside `requestAnimationFrame`.

Re-sizing bug no longer occurs, although the slides do animate after re-size instead of instantly snapping into position. I'm not sure if this was the original intended effect or not, so I'm leaving it as-is. The `css3: false` was for testing, it works with both CSS3 and JQuery animations.
