### PR TITLE
Force string for anchor names

### DIFF
--- a/jquery.fullPage.js
+++ b/jquery.fullPage.js
@@ -2199,6 +2199,9 @@
             if(slide.length){
                 text = text + '-' + slideAnchor;
             }
+            
+            //force string
+            text = '' + text;
 
             //changing slash for dash to make it a valid CSS style
             text = text.replace('/', '-').replace('#','');

--- a/jquery.fullPage.js
+++ b/jquery.fullPage.js
@@ -2189,19 +2189,18 @@
             var slideAnchor = getSlideAnchor(slide);
 
             var sectionIndex = section.index(SECTION_SEL);
+            
+            var text = sectionIndex;
 
-            var text = String(sectionIndex);
-
-            if(options.anchors.length){
+            if (options.anchors.length) {
                 text = sectionAnchor;
             }
 
-            if(slide.length){
+            text = String(text);
+
+            if (slide.length) {
                 text = text + '-' + slideAnchor;
             }
-            
-            //force string
-            text = '' + text;
 
             //changing slash for dash to make it a valid CSS style
             text = text.replace('/', '-').replace('#','');


### PR DESCRIPTION
I used numbers in `data-anchor` and got an error. The `text` variable was an integer which does not have the `replace` method. I fixed it with forcing the variable to be a string.

You want it in another branch, or in another way? :)