### PR TITLE
Scroll slides without animation after resize

### DIFF
--- a/jquery.fullPage.js
+++ b/jquery.fullPage.js
@@ -414,7 +414,13 @@
 
                 //adjusting the position fo the FULL WIDTH slides...
                 if (slides.length > 1) {
-                    landscapeScroll(slidesWrap, slidesWrap.find(SLIDE_ACTIVE_SEL));
+                    // check if we need to scroll without animation after resize
+                    if (resizing) {
+                        silentLandscapeScroll(slidesWrap.find(SLIDE_ACTIVE_SEL));
+                    }
+                    else {
+                        landscapeScroll(slidesWrap, slidesWrap.find(SLIDE_ACTIVE_SEL));
+                    }
                 }
             });
 


### PR DESCRIPTION
Since it's scrolling sections without animation I think it should do the same with slides.
