### PR TITLE
Add prefix for older browser versions

### DIFF
--- a/jquery.fullPage.js
+++ b/jquery.fullPage.js
@@ -1178,7 +1178,12 @@
 
         //IE < 10 pollify for requestAnimationFrame
         window.requestAnimFrame = function(){
-            return window.requestAnimationFrame || function(callback){ callback() }
+            return window.webkitRequestAnimationFrame ||
+                window.mozRequestAnimationFrame ||
+                window.oRequestAnimationFrame ||
+                window.msRequestAnimationFrame ||
+                window.requestAnimationFrame || 
+                function(callback){ callback() }
         }();
 
         /**


### PR DESCRIPTION
Adding prefixes to requestAnimationFrame extend support to older browser.
In my case i tested in FF20.