### PR TITLE
Add minDelta value and exclude node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 bower_components/
+node_modules

--- a/jquery.fullPage.js
+++ b/jquery.fullPage.js
@@ -1075,7 +1075,7 @@
                 var isScrollingVertically = (Math.abs(e.wheelDeltaX) < Math.abs(e.wheelDelta)) || (Math.abs(e.deltaX ) < Math.abs(e.deltaY) || !horizontalDetection);
 
                 //Make sure user intended to scroll
-                if (Math.abs(value) < options.minDelta) {
+                if (options.lockAnchors && Math.abs(value) < options.minDelta) {
                     return;
                 }
 

--- a/jquery.fullPage.js
+++ b/jquery.fullPage.js
@@ -122,6 +122,7 @@
             scrollOverflow: false,
             touchSensitivity: 5,
             normalScrollElementTouchThreshold: 5,
+            minDelta: 20,
 
             //Accessibility
             keyboardScrolling: true,
@@ -1073,6 +1074,11 @@
                 var horizontalDetection = typeof e.wheelDeltaX !== 'undefined' || typeof e.deltaX !== 'undefined';
                 var isScrollingVertically = (Math.abs(e.wheelDeltaX) < Math.abs(e.wheelDelta)) || (Math.abs(e.deltaX ) < Math.abs(e.deltaY) || !horizontalDetection);
 
+                //Make sure user intended to scroll
+                if (Math.abs(value) < options.minDelta) {
+                    return;
+                }
+
                 //Limiting the array to 150 (lets not waste memory!)
                 if(scrollings.length > 149){
                     scrollings.shift();
@@ -1182,7 +1188,7 @@
                 window.mozRequestAnimationFrame ||
                 window.oRequestAnimationFrame ||
                 window.msRequestAnimationFrame ||
-                window.requestAnimationFrame || 
+                window.requestAnimationFrame ||
                 function(callback){ callback() }
         }();
 

--- a/pure javascript (Alpha)/javascript.fullPage.js
+++ b/pure javascript (Alpha)/javascript.fullPage.js
@@ -123,6 +123,7 @@
             easingcss3: 'ease',
             loopHorizontal: true,
             touchSensitivity: 5,
+            minDelta: 20,
 
             //Accessibility
             keyboardScrolling: true,
@@ -1113,6 +1114,11 @@
 
             var value = e.wheelDelta || -e.deltaY || -e.detail;
             var delta = Math.max(-1, Math.min(1, value));
+
+            //Make sure user intended to scroll
+            if (Math.abs(value) < options.minDelta) {
+                return;
+            }
 
             //Limiting the array to 150 (lets not waist memory!)
             if(scrollings.length > 149){

--- a/pure javascript (Alpha)/javascript.fullPage.js
+++ b/pure javascript (Alpha)/javascript.fullPage.js
@@ -1116,7 +1116,7 @@
             var delta = Math.max(-1, Math.min(1, value));
 
             //Make sure user intended to scroll
-            if (Math.abs(value) < options.minDelta) {
+            if (options.lockAnchors && Math.abs(value) < options.minDelta) {
                 return;
             }
 


### PR DESCRIPTION
Hey Álvaro,

## Delta and scrolling on Mac OS X
Thanks for creating this awesome script! I noticed that scroll will often trigger unexpectedly on Mac OS X so I added a minDelta value to work around that. It’s set to a default of 20 which seems like a nice balance between not having to scroll too hard and not accidentally causing unwanted scrolling.

## Node modules
I noticed that node_modules weren't excluded from the repo so I went ahead and did that.

## Minification
I couldn't find any minification task so the didn't compress the code. *That probably means you shouldn't accept this pull request just yet*, but if you tell me how you prefer the code to be compressed (Which tool to use and any options I should enable)  then I'll send a new pull request your way.