### PR TITLE
Text flicker over video on chrome bug fix

### DIFF
--- a/examples/backgroundVideo.html
+++ b/examples/backgroundVideo.html
@@ -58,8 +58,8 @@
 		width: 100%;
 		left: 0;
 		top: 43%;
-		-webkit-transform: translate3d(0,0,0);
-				    transform: translate3d(0,0,0);
+		-webkit-transform: translate3d(0,0,0); /* force draw to avoid text flicker in chrome */
+		        transform: translate3d(0,0,0);
 	}
 
 	/*solves problem with overflowing video in Mac with Chrome */

--- a/examples/backgroundVideo.html
+++ b/examples/backgroundVideo.html
@@ -58,6 +58,8 @@
 		width: 100%;
 		left: 0;
 		top: 43%;
+		-webkit-transform: translate3d(0,0,0);
+				    transform: translate3d(0,0,0);
 	}
 
 	/*solves problem with overflowing video in Mac with Chrome */


### PR DESCRIPTION
On chrome for mac, text over video flickers on scroll. I added a transform to force drawing the text over the video to avoid the flicker. 