### PR TITLE
Added paddingTop and paddingBottom exceptions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,9 +281,9 @@ the fitting by the configured milliseconds.
 
 - `scrollBar`: (default `false`). Determines whether to use scrollbar for the site or not. In case of using scroll bar, the `autoScrolling` functionality will still working as expected. The user will also be free to scroll the site with the scroll bar and fullPage.js will fit the section in the screen when scrolling finishes.
 
-- `paddingTop`: (default `0`) Defines the top padding for each section with a numerical value and its measure (paddingTop: '10px', paddingTop: '10em'...) Useful in case of using a fixed header.
+- `paddingTop`: (default `0`) Defines the top padding for each section with a numerical value and its measure (paddingTop: '10px', paddingTop: '10em'...) Useful in case of using a fixed header. If you need to have a section where this doesn't applies, just add the `fp-no-padding-top` class to that section.
 
-- `paddingBottom`: (default `0`) Defines the bottom padding for each section with a numerical value and its measure (paddingBottom: '10px', paddingBottom: '10em'...). Useful in case of using a fixed footer.
+- `paddingBottom`: (default `0`) Defines the bottom padding for each section with a numerical value and its measure (paddingBottom: '10px', paddingBottom: '10em'...). Useful in case of using a fixed footer. If you need to have a section where this doesn't applies, just add the `fp-no-padding-bottom` class to that section.
 
 - `fixedElements`: (default `null`) Defines which elements will be taken off the scrolling structure of the plugin which is necessary when using the `css3` option to keep them fixed. It requires a string with the jQuery selectors for those elements. (For example: `fixedElements: '#element1, .element2'`)
 

--- a/jquery.fullPage.js
+++ b/jquery.fullPage.js
@@ -49,7 +49,9 @@
     var TABLE_CELL_SEL =        '.' + TABLE_CELL;
     var AUTO_HEIGHT =       'fp-auto-height';
     var AUTO_HEIGHT_SEL =   '.fp-auto-height';
-
+    var NO_PADDING_TOP = 'fp-no-padding-top';
+    var NO_PADDING_BOTTOM = 'fp-no-padding-bottom';
+    
     // section nav
     var SECTION_NAV =           'fp-nav';
     var SECTION_NAV_SEL =       '#' + SECTION_NAV;
@@ -638,11 +640,15 @@
             if(options.paddingTop){
                 section.css('padding-top', options.paddingTop);
             }
-
+            if(section.hasClass(NO_PADDING_TOP)){
+                section.css('padding-top', 0);
+            }
             if(options.paddingBottom){
                 section.css('padding-bottom', options.paddingBottom);
             }
-
+            if(section.hasClass(NO_PADDING_BOTTOM)){
+                section.css('padding-bottom', 0);
+            }
             if (typeof options.sectionsColor[index] !==  'undefined') {
                 section.css('background-color', options.sectionsColor[index]);
             }


### PR DESCRIPTION
Use 'fp-no-padding-top' and 'fp-no-padding-bottom' classes in a section to avoid paddingTop and paddingBottom initializer options respectively in that section.