### PR TITLE
window.innerheight use as primary check of viewport height vs .height…

### DIFF
--- a/jquery.fullPage.js
+++ b/jquery.fullPage.js
@@ -385,7 +385,7 @@
             });
 
             var windowsWidth = $window.width();
-            windowsHeight = $window.height();  //updating global var
+            windowsHeight = getWindowHeight();  //updating global var
 
             //text resizing
             if (options.resize) {
@@ -465,7 +465,7 @@
         var isTouchDevice = navigator.userAgent.match(/(iPhone|iPod|iPad|Android|playbook|silk|BlackBerry|BB10|Windows Phone|Tizen|Bada|webOS|IEMobile|Opera Mini)/);
         var isTouch = (('ontouchstart' in window) || (navigator.msMaxTouchPoints > 0) || (navigator.maxTouchPoints));
         var container = $(this);
-        var windowsHeight = $window.height();
+        var windowsHeight = getWindowHeight();
         var isResizing = false;
         var isWindowFocused = true;
         var lastScrolledDestiny;
@@ -508,7 +508,7 @@
             FP.setAllowScrolling(true);
 
             //due to https://github.com/alvarotrigo/fullPage.js/issues/1502
-            windowsHeight = $window.height();
+            windowsHeight = getWindowHeight();
 
             FP.setAutoScrolling(options.autoScrolling, 'internal');
 
@@ -956,7 +956,7 @@
                     else if(options.autoScrolling){
 
                         //is the movement greater than the minimum resistance to scroll?
-                        if (Math.abs(touchStartY - touchEndY) > ($window.height() / 100 * options.touchSensitivity)) {
+                        if (Math.abs(touchStartY - touchEndY) > (getWindowHeight() / 100 * options.touchSensitivity)) {
                             if (touchStartY > touchEndY) {
                                 scrolling('down', scrollable);
                             } else if (touchEndY > touchStartY) {
@@ -1745,7 +1745,7 @@
 
                 //if the keyboard is NOT visible
                 if (!activeElement.is('textarea') && !activeElement.is('input') && !activeElement.is('select')) {
-                    var currentHeight = $window.height();
+                    var currentHeight = getWindowHeight();
 
                     //making sure the change in the viewport size is enough to force a rebuild. (20 % of the window to avoid problems when hidding scroll bars)
                     if( Math.abs(currentHeight - previousHeight) > (20 * Math.max(previousHeight, currentHeight) / 100) ){
@@ -1774,7 +1774,7 @@
 
             //only calculating what we need. Remember its called on the resize event.
             var isBreakingPointWidth = widthLimit && $window.width() < widthLimit;
-            var isBreakingPointHeight = heightLimit && $window.height() < heightLimit;
+            var isBreakingPointHeight = heightLimit && getWindowHeight() < heightLimit;
 
             if(widthLimit && heightLimit){
                 FP.setResponsive(isBreakingPointWidth || isBreakingPointHeight);
@@ -1954,6 +1954,10 @@
             }
 
             return sectionHeight;
+        }
+
+        function getWindowHeight(){
+            return window.innerHeight || $window.height();
         }
 
         /**


### PR DESCRIPTION
`window.innerheight` used as primary check of viewport height vs `$(window).height` .It delivers reliable height of viewport w/o chrome compared to others height alternatives. Other options tried were:

$(window).height();
$('body').height());
$('html').height());
document.documentElement.clientHeight;
document.body.clientHeight;
$(document).height();