### PR TITLE
Fixed: Scroll failing when first section be set to auto height

### DIFF
--- a/jquery.fullPage.js
+++ b/jquery.fullPage.js
@@ -1178,7 +1178,8 @@
                 if(typeof dest === 'undefined'){ return; } //there's no element to scroll, leaving the function
 
                 //auto height? Scrolling only a bit, the next element's height. Otherwise the whole viewport.
-                var dtop = element.hasClass(AUTO_HEIGHT) ? (dest.top - windowsHeight + element.height()) : dest.top;
+                var dtop = element.hasClass(AUTO_HEIGHT) && dest.top ? (dest.top - windowsHeight + element.height()) : dest.top;
+
 
                 //local variables
                 var v = {

--- a/jquery.fullPage.js
+++ b/jquery.fullPage.js
@@ -1180,7 +1180,6 @@
                 //auto height? Scrolling only a bit, the next element's height. Otherwise the whole viewport.
                 var dtop = element.hasClass(AUTO_HEIGHT) && dest.top ? (dest.top - windowsHeight + element.height()) : dest.top;
 
-
                 //local variables
                 var v = {
                     element: element,


### PR DESCRIPTION
Fixed: Scroll failing when first section be set to auto height
After scroll down to other section, can not scrolling up to first section,
first section will not be display again .

https://github.com/alvarotrigo/fullPage.js/pull/1679