### PR TITLE
Fix the wrong active section flag under normal scroll

### DIFF
--- a/jquery.fullPage.js
+++ b/jquery.fullPage.js
@@ -790,18 +790,17 @@
             if(!options.autoScrolling || options.scrollBar){
                 var currentScroll = $window.scrollTop();
                 var visibleSectionIndex = 0;
-                var initial = Math.abs(currentScroll - document.querySelectorAll(SECTION_SEL)[0].offsetTop);
+                var screen_mid = currentScroll + ($window.height() / 2.0);
 
                 //taking the section which is showing more content in the viewport
                 var sections =  document.querySelectorAll(SECTION_SEL);
                 for (var i = 0; i < sections.length; ++i) {
                     var section = sections[i];
 
-                    var current = Math.abs(currentScroll - section.offsetTop);
-
-                    if(current < initial){
+                    // Pick the the last section which passes the middle line of the screen.
+                    if (section.offsetTop <= screen_mid)
+                    {
                         visibleSectionIndex = i;
-                        initial = current;
                     }
                 }
 

--- a/jquery.fullPage.js
+++ b/jquery.fullPage.js
@@ -809,7 +809,7 @@
 
                 //setting the visible section as active when manually scrolling
                 //executing only once the first time we reach the section
-                if(!currentSection.hasClass(ACTIVE) && !currentSection.hasClass(AUTO_HEIGHT)){
+                if(!currentSection.hasClass(ACTIVE)){
                     isScrolling = true;
                     var leavingSection = $(SECTION_ACTIVE_SEL);
                     var leavingSectionIndex = leavingSection.index(SECTION_SEL) + 1;


### PR DESCRIPTION
Under normal scroll (`autoScrolling: false`), when a section is longer than the window height, the active flag in navigation can be wrong. This PR fixes this issue.

The current logic (in the base fork) calculates the difference between the `section.offsetTop` and `$window.scrollTop()` for each section and pick the one with the smallest diff as active. However, this can be wrong. For example, suppose there are two sections A and B, where section A is much longer than the window height. Consider the case when you have *just* scrolled B entering the viewport. At this point, section B occupies very little area of the window, whereas section A still dominates. However, `diff(A.offsetTop, window.ScrollTop) < diff(B.offsetTop , window.ScrollTop)` as A is very long and the top of B is much closer to the window scrollTop. This will select section B as the current active section *wrongly*.

To fix this issue, I changed the logic to explicitly find _which section passes the middle line of the screen_. This will work correctly for the scenario above, where the top of section B obviously does not pass the middle line. 

Corner cases:
* If section B is short and there is a section C coming, selecting section B as active when it passes the middle line is still acceptable because it is the section at the screen center (which is the center of attention).
* In the case of `autoScrolling: true`, my modification works as well. So there is no negative side-effect.
