### PR TITLE
Add support for custom getDestinationPosition

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,8 @@ $(document).ready(function() {
 		afterRender: function(){},
 		afterResize: function(){},
 		afterSlideLoad: function(anchorLink, index, slideAnchor, slideIndex){},
-		onSlideLeave: function(anchorLink, index, slideIndex, direction, nextSlideIndex){}
+		onSlideLeave: function(anchorLink, index, slideIndex, direction, nextSlideIndex){},
+ 		getDestinationPosition: function(dest, element){}
 	});
 });
 ```
@@ -705,6 +706,35 @@ Example:
 			}
 		}
 	});
+```
+
+###getDestinationPosition (`dest`, `element`)
+This callback is fired before a scroll event to calcuate the target position. Use this to optionally override the default behavior.
+
+Parameters:
+
+- `dest`: the target element's position.
+- `element`: the target element..
+
+Example:
+
+```javascript
+    $('#fullpage').fullpage({
+        getDestinationPosition: function(dest, element) {
+            // Position the element in the middle of the viewport if there's room,
+            // or at the top if there isn't.
+            var elementOffset = element.offset().top;
+            var elementHeight = element.height();
+            var windowHeight = $(window).height();
+
+            var position = elementOffset;
+            if (elementHeight < windowHeight) {
+              position = elementOffset - (windowHeight / 2 - elementHeight / 2);
+            }
+
+            return position;
+        }
+    });
 ```
 
 ####Cancelling a move before it takes place

--- a/jquery.fullPage.js
+++ b/jquery.fullPage.js
@@ -164,7 +164,8 @@
             afterResize: null,
             afterReBuild: null,
             afterSlideLoad: null,
-            onSlideLeave: null
+            onSlideLeave: null,
+            getDestinationPosition: null
         }, options);
 
         displayWarnings();
@@ -1284,6 +1285,12 @@
         * the height of the section.
         */
         function getDestinationPosition(dest, element){
+            // Use a user-defined handler if we have one.
+            if (options.getDestinationPosition) {
+                var position = options.getDestinationPosition(dest, element);
+                previousDestTop = position;
+                return position;
+            }
 
             //top of the desination will be at the top of the viewport
             var position = dest.top;


### PR DESCRIPTION
Allow the user to optionally pass a custom `getDestinationPosition` handler. 
My use case is something like this:

```javascript
    $('#fullpage').fullpage({
        getDestinationPosition: function(dest, element) {
            // Position the element in the middle of the viewport if there's room,
            // or at the top if there isn't.
            var elementOffset = element.offset().top;
            var elementHeight = element.height();
            var windowHeight = $(window).height();

            var position = elementOffset;
            if (elementHeight < windowHeight) {
              position = elementOffset - (windowHeight / 2 - elementHeight / 2);
            }

            return position;
        }
    });
```