### PR TITLE
Change default 'active' class to 'fp-active'

### DIFF
--- a/jquery.fullPage.js
+++ b/jquery.fullPage.js
@@ -35,7 +35,7 @@
     var DESTROYED =             'fp-destroyed';
     var ENABLED =               'fp-enabled';
     var VIEWING_PREFIX =        'fp-viewing';
-    var ACTIVE =                'active';
+    var ACTIVE =                'fp-active';
     var ACTIVE_SEL =            '.' + ACTIVE;
     var COMPLETELY =            'fp-completely';
     var COMPLETELY_SEL =        '.' + COMPLETELY;


### PR DESCRIPTION
Hey,
I'm wondering... wouldn't be better to change default `active` class to `fp-active` to prevent namespace conflicts? For example with Bootstrap `active` class. I ran into this issue today and changed it.

P.S. Thanks for the great addon! 
