### PR TITLE
Fix: scrollToAnchor may not be called

### DIFF
--- a/jquery.fullPage.js
+++ b/jquery.fullPage.js
@@ -518,7 +518,7 @@
             //setting the class for the body element
             setBodyClass();
 
-            $window.on('load', function() {
+            $(function(){
                 scrollToAnchor();
             });
         }

--- a/jquery.fullPage.js
+++ b/jquery.fullPage.js
@@ -518,9 +518,10 @@
             //setting the class for the body element
             setBodyClass();
 
-            $(function(){
+            if(document.readyState === 'complete'){
                 scrollToAnchor();
-            });
+            }
+            $window.on('load', scrollToAnchor);
         }
 
         function bindEvents(){


### PR DESCRIPTION
on load will not be called if it's binded after onload event,
and jquery ready function will always be called whether document is ready.
(if document has been ready, it will be called immediately)

Found this problem cause I use fullpage in ajax callback (when onload has passed)