### PR TITLE
AllowScrolling added to options

### DIFF
--- a/jquery.fullPage.js
+++ b/jquery.fullPage.js
@@ -147,6 +147,7 @@
             keyboardScrolling: true,
             animateAnchor: true,
             recordHistory: true,
+            allowScrolling: true,
 
             //design
             controlArrows: true,
@@ -513,7 +514,7 @@
             setOptionsFromDOM();
 
             prepareDom();
-            FP.setAllowScrolling(true);
+            FP.setAllowScrolling(options.allowScrolling);
 
             FP.setAutoScrolling(options.autoScrolling, 'internal');
 


### PR DESCRIPTION
I want to have ability to set 'allowScrolling' to false when I create fullpage, so that I can disable scrolling for mouse and keyboard, and make scroll working only with buttons on the page, which will trigger 

```
$.fn.fullpage.setAllowScrolling(true);
$.fn.fullpage.setKeyboardScrolling(true);
```