### PR TITLE
fullpage.js Angular 2 directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -753,6 +753,7 @@ Want to build fullpage.js distribution files? Please see [Build Tasks](https://g
 - [fullPage.js jsDelivr CDN](http://www.jsdelivr.com/#!jquery.fullpage)
 - [fullPage.js plugin for October CMS](http://octobercms.com/plugin/freestream-parallax)
 - [fullPage.js wordpress plugin](https://wordpress.org/plugins/wp-fullpage/)
+- [fullPage.js Angular2 directive](https://github.com/meiblorn/ng2-fullpage)
 - [fullPage.js angular directive](https://github.com/hellsan631/angular-fullpage.js)
 - [Angular fullPage.js - Adaptation for Angular.js v1.x](https://github.com/mmautomatizacion/angular-fullpage.js)
 - [Integrating fullPage.js with Wordpress (Tutorial)](http://premium.wpmudev.org/blog/build-apple-inspired-full-page-scrolling-pages-for-your-wordpress-site/)


### PR DESCRIPTION
Port library for a new modern [Angular 2](http://angular.io) framework.

For additional details visit project github page: [https://github.com/meiblorn/ng2-fullpage](https://github.com/meiblorn/ng2-fullpage) or [demo](meiblorn.github.io/ng2-fullpage)