### PR TITLE
Fix scrollbar drag issue and mobile touch drag issue on autoScrolling false and fitToSection true.

### DIFF
--- a/jquery.fullPage.js
+++ b/jquery.fullPage.js
@@ -1700,7 +1700,7 @@
 
         //prevent scrolling on mousedown and/or touchstart
         function interactionStartHandler(e) {
-            if (options.fitToSection) {
+            if (!options.autoScrolling && options.fitToSection) {
                 //if the page is currently scrolling, stop it
                 $htmlBody.stop();
                 //prevent fitToSection while scrollbar is mousedowned
@@ -1710,7 +1710,7 @@
 
         //enable fitToSection on mouseup and/or touchend
         function interactionEndHandler(e) {
-            if (options.fitToSection) {
+            if (!options.autoScrolling && options.fitToSection) {
                 //re-enable fitToSection
                 canScroll = true;
                 //scroll to fit whole section

--- a/jquery.fullPage.js
+++ b/jquery.fullPage.js
@@ -97,7 +97,7 @@
         disableMouse: true,
 
         //fixing bug in iScroll with links: https://github.com/cubiq/iscroll/issues/783
-        click: true 
+        click: true
     };
 
     $.fn.fullpage = function(options) {
@@ -558,7 +558,12 @@
                 //Scrolls the slider to the given slide destination for the given section
                 .on('click touchstart', SLIDES_NAV_LINK_SEL, slideBulletHandler)
 
-                .on('click', SECTION_NAV_TOOLTIP_SEL, tooltipTextHandler);
+                .on('click', SECTION_NAV_TOOLTIP_SEL, tooltipTextHandler)
+
+                //prevent fitToSection on user interaction with the screen
+                .on('mousedown touchstart', interactionStartHandler)
+
+                .on('mouseup touchend', interactionEndHandler);
 
             //Scrolling horizontally when clicking on the slider controls.
             $(SECTION_SEL).on('click touchstart', SLIDES_ARROW_SEL, slideArrowHandler);
@@ -1693,6 +1698,26 @@
             }
         }
 
+        //prevent scrolling on mousedown and/or touchstart
+        function interactionStartHandler(e) {
+            if (options.fitToSection) {
+                //if the page is currently scrolling, stop it
+                $htmlBody.stop();
+                //prevent fitToSection while scrollbar is mousedowned
+                canScroll = false;
+            }
+        }
+
+        //enable fitToSection on mouseup and/or touchend
+        function interactionEndHandler(e) {
+            if (options.fitToSection) {
+                //re-enable fitToSection
+                canScroll = true;
+                //scroll to fit whole section
+                scrollHandler();
+            }
+        }
+
         //binding the mousemove when the mouse's middle button is released
         function mouseDownHandler(e){
             //middle button
@@ -2578,7 +2603,9 @@
                 .off('mouseleave', SECTION_NAV_SEL + ' li')
                 .off('click', SLIDES_NAV_LINK_SEL)
                 .off('mouseover', options.normalScrollElements)
-                .off('mouseout', options.normalScrollElements);
+                .off('mouseout', options.normalScrollElements)
+                .off('mousedown touchstart', interactionStartHandler)
+                .off('mouseup touchend', interactionEndHandler);
 
             $(SECTION_SEL)
                 .off('click', SLIDES_ARROW_SEL);
@@ -2722,7 +2749,7 @@
         function showError(type, text){
             console && console[type] && console[type]('fullPage: ' + text);
         }
-    }; //end of $.fn.fullpage  
+    }; //end of $.fn.fullpage
 
     /**
      * An object to handle overflow scrolling.


### PR DESCRIPTION
Symptom: when you turn off `autoScrolling` and turn on `fitToSection`, then try to navigate using the scrollbar, the page doesn't transition smoothly, it always try to fit section to screen and ignore scrollbar dragging, creates some kind of flickering effect. The same sometimes occurs on mobile when user tries to scroll the page up/down.

You can reproduce the issue here on your example page: http://alvarotrigo.com/fullPage/examples/normalScroll.html

Reproduction: Drag the scrollbar so that the section's edge is in the middle of the screen (don't release the scrollbar yet), then as soon as the page starts fitting the section to the screen, start dragging the scrollbar again, you'll see the problem. (It's actually easier to see if you set the fitToSectionDelay to 100).

Side note: I tried to detect the scrollbar mousedown by using `e.target !== $('html').get(0)`, but that doesn't work on Mac, so I'm using mousedown on `$(document)` instead.