### PR TITLE
Add option for section nav container

### DIFF
--- a/jquery.fullPage.js
+++ b/jquery.fullPage.js
@@ -55,6 +55,7 @@
     // section nav
     var SECTION_NAV =           'fp-nav';
     var SECTION_NAV_SEL =       '#' + SECTION_NAV;
+    var SECTION_NAV_CONTAINER = 'body';
     var SECTION_NAV_TOOLTIP =   'fp-tooltip';
     var SECTION_NAV_TOOLTIP_SEL='.'+SECTION_NAV_TOOLTIP;
     var SHOW_ACTIVE_TOOLTIP =   'fp-show-active';
@@ -164,7 +165,7 @@
             //Custom selectors
             sectionSelector: SECTION_DEFAULT_SEL,
             slideSelector: SLIDE_DEFAULT_SEL,
-
+            navigationContainer: SECTION_NAV_CONTAINER,
 
             //events
             afterLoad: null,
@@ -782,7 +783,7 @@
         * Creates a vertical navigation bar.
         */
         function addVerticalNavigation(){
-            $body.append('<div id="' + SECTION_NAV + '"><ul></ul></div>');
+            $(options.navigationContainer).append('<div id="' + SECTION_NAV + '"><ul></ul></div>');
             var nav = $(SECTION_NAV_SEL);
 
             nav.addClass(function() {


### PR DESCRIPTION
I've added an option to change the section nav's container so it can appended to elements other than the body (which remains default).

Useful in cases where you're doing things like ajax loading new page fragments that don't use fullPage.js or where you need more control over positioning.