### PR TITLE
remove class RESPONSIVE from $body in destroyStructure function

### DIFF
--- a/jquery.fullPage.js
+++ b/jquery.fullPage.js
@@ -97,7 +97,7 @@
         disableMouse: true,
 
         //fixing bug in iScroll with links: https://github.com/cubiq/iscroll/issues/783
-        click: true 
+        click: true
     };
 
     $.fn.fullpage = function(options) {
@@ -2627,6 +2627,11 @@
             // remove .fp-enabled class
             $('html').removeClass(ENABLED);
 
+            // remove .fp-responsive class
+            if ($body.hasClass(RESPONSIVE)) {
+              $body.removeClass(RESPONSIVE);
+            }
+
             // remove all of the .fp-viewing- classes
             $.each($body.get(0).className.split(/\s+/), function (index, className) {
                 if (className.indexOf(VIEWING_PREFIX) === 0) {
@@ -2722,7 +2727,7 @@
         function showError(type, text){
             console && console[type] && console[type]('fullPage: ' + text);
         }
-    }; //end of $.fn.fullpage  
+    }; //end of $.fn.fullpage
 
     /**
      * An object to handle overflow scrolling.

--- a/jquery.fullPage.js
+++ b/jquery.fullPage.js
@@ -2628,9 +2628,7 @@
             $('html').removeClass(ENABLED);
 
             // remove .fp-responsive class
-            if ($body.hasClass(RESPONSIVE)) {
-              $body.removeClass(RESPONSIVE);
-            }
+            $body.removeClass(RESPONSIVE);
 
             // remove all of the .fp-viewing- classes
             $.each($body.get(0).className.split(/\s+/), function (index, className) {


### PR DESCRIPTION
This was tripping me up for awhile. After destroying fullPage the fp-responsive class remained on the body and when I re-initialized fullPage it wouldn't go into responsive mode. Removing this class from the body when destroying fullPage fixed this problem.

Great plugin btw! Thank you!