### PR TITLE
removes redundant getTransforms

### DIFF
--- a/jquery.fullPage.js
+++ b/jquery.fullPage.js
@@ -504,7 +504,6 @@
                     getTransforms: getTransforms,
                     lazyLoad: lazyLoad,
                     addAnimation: addAnimation,
-                    getTransforms: getTransforms,
                     performHorizontalMove: performHorizontalMove,
                     silentLandscapeScroll: silentLandscapeScroll
                 }


### PR DESCRIPTION
getFullpageData sets getTransforms option twice, causing issues in IE