### PR TITLE
Bugfix: continuousHorizontal should default to false

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
+.idea
 bower_components/
 /node_modules

--- a/jquery.fullPage.js
+++ b/jquery.fullPage.js
@@ -135,7 +135,7 @@
             loopTop: false,
             loopHorizontal: true,
             continuousVertical: false,
-            continuousHorizontal: true,
+            continuousHorizontal: false,
             scrollHorizontally: false,
             interlockedSlides: false,
             resetSliders: false,
@@ -2827,7 +2827,7 @@
             extensions.forEach(function(extension){
                 //is the option set to true?
                 if(options[extension]){
-                    showError('warn', 'fullpage.js extensions require jquery.fullpage.extensions.min.js file instead of the usual jquery.fullpage.js');
+                    showError('warn', 'fullpage.js extensions require jquery.fullpage.extensions.min.js file instead of the usual jquery.fullpage.js. Requested: '+ extension);
                 }
             });
 


### PR DESCRIPTION
continuousHorizontal was set to `true` resulting in a console warning.
Updated to `continuousHorizontal: false`.

Also made the warning clearer by showing what extension is requested.