### PR TITLE
Use $ instead of jQuery

### DIFF
--- a/jquery.fullPage.js
+++ b/jquery.fullPage.js
@@ -2937,7 +2937,7 @@
 
             scrollable.height(scrollHeight);
             scrollable.each(function() {
-                var $this = jQuery(this);
+                var $this = $(this);
                 var iScrollInstance = $this.data('iscrollInstance');
                 if (iScrollInstance) {
                     $.each(iscrollHandler.iScrollInstances, function(){


### PR DESCRIPTION
I got error since I didn't have jQuery globally defined. All other places in the code `$` is used as well, not sure why `jQuery` was used here