### PR TITLE
Prevent keypresses to fire prematurely

### DIFF
--- a/jquery.fullPage.js
+++ b/jquery.fullPage.js
@@ -2546,11 +2546,13 @@
         * Adds the possibility to auto scroll through sections on touch devices.
         */
         function addTouchHandler(){
-            if(options.autoScrolling && (isTouchDevice || isTouch)){
+            if(isTouchDevice || isTouch){
                 //Microsoft pointers
                 var MSPointer = getMSPointer();
 
-                $body.off('touchmove ' + MSPointer.move).on('touchmove ' + MSPointer.move, preventBouncing);
+                if(options.autoScrolling){
+                    $body.off('touchmove ' + MSPointer.move).on('touchmove ' + MSPointer.move, preventBouncing);
+                }
 
                 $(WRAPPER_SEL)
                     .off('touchstart ' +  MSPointer.down).on('touchstart ' + MSPointer.down, touchStartHandler)

--- a/jquery.fullPage.js
+++ b/jquery.fullPage.js
@@ -187,7 +187,6 @@
 
         //flag to avoid very fast sliding for landscape sliders
         var slideMoving = false;
-        var sectionMoving = false;
 
         var isTouchDevice = navigator.userAgent.match(/(iPhone|iPod|iPad|Android|playbook|silk|BlackBerry|BB10|Windows Phone|Tizen|Bada|webOS|IEMobile|Opera Mini)/);
         var isTouch = (('ontouchstart' in window) || (navigator.msMaxTouchPoints > 0) || (navigator.maxTouchPoints));
@@ -1451,7 +1450,6 @@
         * Performs the vertical movement (by CSS3 or by jQuery)
         */
         function performMovement(v){
-            sectionMoving = true;
             // using CSS3 translate functionality
             if (options.css3 && options.autoScrolling && !options.scrollBar) {
 
@@ -1573,7 +1571,6 @@
         */
         function afterSectionLoads (v){
             continuousVerticalFixSectionOrder(v);
-            sectionMoving = false;
 
             //callback (afterLoad) if the site is not just resizing and readjusting the slides
             $.isFunction(options.afterLoad) && !v.localIsResizing && options.afterLoad.call(v.element, v.anchorLink, (v.sectionIndex + 1));
@@ -1750,7 +1747,10 @@
                     e.preventDefault();
                 }
 
-                if (sectionMoving) return;
+                //do nothing if we can not scroll or we are not using horizotnal key arrows.
+                if(!canScroll && [37,39].indexOf(e.which) < 0){
+                    return;
+                }
 
                 controlPressed = e.ctrlKey;
 

--- a/jquery.fullPage.js
+++ b/jquery.fullPage.js
@@ -187,6 +187,7 @@
 
         //flag to avoid very fast sliding for landscape sliders
         var slideMoving = false;
+        var sectionMoving = false;
 
         var isTouchDevice = navigator.userAgent.match(/(iPhone|iPod|iPad|Android|playbook|silk|BlackBerry|BB10|Windows Phone|Tizen|Bada|webOS|IEMobile|Opera Mini)/);
         var isTouch = (('ontouchstart' in window) || (navigator.msMaxTouchPoints > 0) || (navigator.maxTouchPoints));
@@ -228,7 +229,7 @@
         * It changes the scroll bar visibility and the history of the site as a result.
         */
         function setAutoScrolling(value, type){
-            //removing the transformation 
+            //removing the transformation
             if(!value){
                 silentScroll(0);
             }
@@ -1450,6 +1451,7 @@
         * Performs the vertical movement (by CSS3 or by jQuery)
         */
         function performMovement(v){
+            sectionMoving = true;
             // using CSS3 translate functionality
             if (options.css3 && options.autoScrolling && !options.scrollBar) {
 
@@ -1571,6 +1573,7 @@
         */
         function afterSectionLoads (v){
             continuousVerticalFixSectionOrder(v);
+            sectionMoving = false;
 
             //callback (afterLoad) if the site is not just resizing and readjusting the slides
             $.isFunction(options.afterLoad) && !v.localIsResizing && options.afterLoad.call(v.element, v.anchorLink, (v.sectionIndex + 1));
@@ -1746,6 +1749,8 @@
                 if($.inArray(keyCode, keyControls) > -1){
                     e.preventDefault();
                 }
+
+                if (sectionMoving) return;
 
                 controlPressed = e.ctrlKey;
 
@@ -2634,7 +2639,7 @@
             // The first section can have a negative value in iOS 10. Not quite sure why: -0.0142822265625
             // that's why we round it to 0.
             var roundedTop = Math.round(top);
-            
+
             if (options.css3 && options.autoScrolling && !options.scrollBar){
                 var translate3d = 'translate3d(0px, -' + roundedTop + 'px, 0px)';
                 transformContainer(translate3d, false);


### PR DESCRIPTION
Hi Alvaro,

I noticed that the `onLeave` callback was firing too soon, which caused my implementation to break when pressing down (next slide) multiple times. The callback would fire, even though the previous animation was not completed yet.

So I added this check in the `keydownHandler()` function. It's not in the same if-statement as the others, because this would sometimes cause a normal "down" event to fire, scrolling the page one tick, showing a piece of the next section, and then centering on the proper section again.

Hope you find this helpful.

Regards,
Jorn
