### PR TITLE
Re-re-submit of pull request #2665

### DIFF
--- a/jquery.fullPage.js
+++ b/jquery.fullPage.js
@@ -606,12 +606,12 @@
             * Ignoring the scrolls over the specified selectors.
             */
             if(options.normalScrollElements){
-                $document.on('mouseenter', options.normalScrollElements, function () {
-                    setMouseWheelScrolling(false);
+                $document.on('mouseenter touchstart', options.normalScrollElements, function () {
+                    setAllowScrolling(false);
                 });
 
-                $document.on('mouseleave', options.normalScrollElements, function(){
-                    setMouseWheelScrolling(true);
+                $document.on('mouseleave touchend', options.normalScrollElements, function(){
+                    setAllowScrolling(true);
                 });
             }
         }


### PR DESCRIPTION
Addressing issue #2664

- *Library version*: 2.9.4.

- *Issue*: 
    - iframes are not recognized correctly as "normalScrollElements" during touch events, as they don't propagate touch events within them.

- *Proposed solution*: 
    - add explicit `touchstart` and `touchend` listeners to "normalScrollElements" 
    - disable general scrolling on `touchstart` event (instead of disabling only mouse wheel scrolling)
    - re-enable general scrolling on `touchend` event

- *Proposed changes*:
    - edit file jquery.fullPage.js [lines 604 to 620]