### PR TITLE
Allow forced scroll to top or bottom of section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 &nbsp;&nbsp; **|**&nbsp;&nbsp; *7Kb gziped* &nbsp;&nbsp;**|**&nbsp;&nbsp; *Created by [@imac2](https://twitter.com/imac2)*
 
 - [Live demo](http://alvarotrigo.com/fullPage/)
-- [Wordpress theme](http://alvarotrigo.com/fullPage/utils/wordpress-y-theme.html)
+- [Wordpress theme](http://alvarotrigo.com/fullPage/utils/wordpress.html)
 - [fullpage.js Extensions](http://alvarotrigo.com/fullPage/extensions/)
 - [Frequently Answered Questions](https://github.com/alvarotrigo/fullPage.js/wiki/FAQ---Frequently-Answered-Questions)
 
@@ -868,8 +868,7 @@ To see the list of recent changes, see [Releases section](https://github.com/alv
 Want to build fullpage.js distribution files? Please see [Build Tasks](https://github.com/alvarotrigo/fullPage.js/wiki/Build-tasks)
 
 # Resources
-- [Wordpress theme 1](http://alvarotrigo.com/fullPage/utils/wordpress-y-theme.html) 
-- [Wordpress theme 2](http://alvarotrigo.com/fullPage/utils/wordpress.html)
+- [Wordpress theme](http://alvarotrigo.com/fullPage/utils/wordpress.html)
 - [CSS Easing Animation Tool - Matthew Lein](http://matthewlein.com/ceaser/) (useful to define the `easingcss3` value)
 - [fullPage.js jsDelivr CDN](http://www.jsdelivr.com/#!jquery.fullpage)
 - [fullPage.js plugin for October CMS](http://octobercms.com/plugin/freestream-parallax)

--- a/README_SPANISH.md
+++ b/README_SPANISH.md
@@ -865,8 +865,7 @@ Solo disponible en ingles :)
 Want to build fullpage.js distribution files? Please see [Build Tasks](https://github.com/alvarotrigo/fullPage.js/wiki/Build-tasks)
 
 # Recursos
-- [Template de Wordpress 1](http://alvarotrigo.com/fullPage/utils/wordpress-y-theme.html)
-- [Template de Wordpress 2](http://alvarotrigo.com/fullPage/utils/wordpress.html)
+- [Template de Wordpress](http://alvarotrigo.com/fullPage/utils/wordpress.html)
 - [Herramienta de animacion de CSS Easing - Matthew Lein](http://matthewlein.com/ceaser/) (útil para definir la opción `easingcss3`)
 - [fullPage.js jsDelivr CDN](http://www.jsdelivr.com/#!jquery.fullpage)
 - [fullPage.js plugin para October CMS](http://octobercms.com/plugin/freestream-parallax)

--- a/jquery.fullPage.js
+++ b/jquery.fullPage.js
@@ -150,6 +150,7 @@
             touchSensitivity: 5,
             normalScrollElementTouchThreshold: 5,
             bigSectionsDestination: null,
+            forcedPosition: null,
 
             //Accessibility
             keyboardScrolling: true,
@@ -1373,17 +1374,23 @@
             var sectionBottom = position - windowsHeight + element.outerHeight();
             var bigSectionsDestination = options.bigSectionsDestination;
 
-            //is the destination element bigger than the viewport?
-            if(element.outerHeight() > windowsHeight){
-                //scrolling up?
-                if(!isScrollingDown && !bigSectionsDestination || bigSectionsDestination === 'bottom' ){
+            // if there is no forced position, continue as normal
+            if (!options.forcedPosition) {
+                //is the destination element bigger than the viewport?
+                if(element.outerHeight() > windowsHeight){
+                    //scrolling up?
+                    if(!isScrollingDown && !bigSectionsDestination || bigSectionsDestination === 'bottom' ){
+                        position = sectionBottom;
+                    }
+                }
+
+                //sections equal or smaller than the viewport height && scrolling down? ||  is resizing and its in the last section
+                else if(isScrollingDown || (isResizing && element.is(':last-child')) ){
+                    //The bottom of the destination will be at the bottom of the viewport
                     position = sectionBottom;
                 }
-            }
-
-            //sections equal or smaller than the viewport height && scrolling down? ||  is resizing and its in the last section
-            else if(isScrollingDown || (isResizing && element.is(':last-child')) ){
-                //The bottom of the destination will be at the bottom of the viewport
+            // only check for 'bottom'. no need to check for 'top' because that's the default position
+            } else if (options.forcedPosition === 'bottom') {
                 position = sectionBottom;
             }
 


### PR DESCRIPTION
I was using this library but I had a need to always force the section to align to the bottom instead of changing depending on where you're scrolling from. Setting `forcedPosition` to `bottom` has the section always position at the bottom of the viewport, `top` the opposite. By default it's `null` which allows it to function as it currently does.

1- Make sure to commit it to the `dev` branch!
2- Read https://github.com/alvarotrigo/fullPage.js/wiki/Contributing-to-fullpage.js