### PR TITLE
Allow forced scroll to top or bottom of section.

### DIFF
--- a/jquery.fullPage.js
+++ b/jquery.fullPage.js
@@ -150,6 +150,7 @@
             touchSensitivity: 5,
             normalScrollElementTouchThreshold: 5,
             bigSectionsDestination: null,
+            forcedPosition: null,
 
             //Accessibility
             keyboardScrolling: true,
@@ -1357,17 +1358,23 @@
             var sectionBottom = position - windowsHeight + element.outerHeight();
             var bigSectionsDestination = options.bigSectionsDestination;
 
-            //is the destination element bigger than the viewport?
-            if(element.outerHeight() > windowsHeight){
-                //scrolling up?
-                if(!isScrollingDown && !bigSectionsDestination || bigSectionsDestination === 'bottom' ){
+            // if there is no forced position, continue as normal
+            if (!options.forcedPosition) {
+                //is the destination element bigger than the viewport?
+                if(element.outerHeight() > windowsHeight){
+                    //scrolling up?
+                    if(!isScrollingDown && !bigSectionsDestination || bigSectionsDestination === 'bottom' ){
+                        position = sectionBottom;
+                    }
+                }
+
+                //sections equal or smaller than the viewport height && scrolling down? ||  is resizing and its in the last section
+                else if(isScrollingDown || (isResizing && element.is(':last-child')) ){
+                    //The bottom of the destination will be at the bottom of the viewport
                     position = sectionBottom;
                 }
-            }
-
-            //sections equal or smaller than the viewport height && scrolling down? ||  is resizing and its in the last section
-            else if(isScrollingDown || (isResizing && element.is(':last-child')) ){
-                //The bottom of the destination will be at the bottom of the viewport
+            // only check for 'bottom'. no need to check for 'top' because that's the default position
+            } else if (options.forcedPosition === 'bottom') {
                 position = sectionBottom;
             }
 


### PR DESCRIPTION
I was using this library but I had a need to always force the section to align to the bottom instead of changing depending on where you're scrolling from. Setting `forcedPosition` to `bottom` has the section always position at the bottom of the viewport, `top` the opposite. By default it's `null` which allows it to functional as it currently does.

Same as #2903, just comitted to dev branch

1- Make sure to commit it to the `dev` branch!
2- Read https://github.com/alvarotrigo/fullPage.js/wiki/Contributing-to-fullpage.js