### PR TITLE
Improved: adding color to vertical and horizontal navigation dots

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ $(document).ready(function() {
 		navigation: false,
 		navigationPosition: 'right',
 		navigationTooltips: ['firstSlide', 'secondSlide'],
+		navigationColor: '#333',
 		showActiveTooltip: false,
 		slidesNavigation: false,
 		slidesNavPosition: 'bottom',
@@ -451,6 +452,8 @@ $('#fullpage').fullpage({
 - `navigationPosition`: (default `none`) It can be set to `left` or `right` and defines which position the navigation bar will be shown (if using one).
 
 - `navigationTooltips`: (default []) Defines the tooltips to show for the navigation circles in case they are being used. Example: `navigationTooltips: ['firstSlide', 'secondSlide']`. You can also define them by using the attribute `data-tooltip` in each section if you prefer.
+
+- `navigationColor`: (default `#333`) Defines the CSS color for the small circles in the navigation bar.
 
 - `showActiveTooltip`: (default `false`) Shows a persistent tooltip for the actively viewed section in the vertical navigation.
 

--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ $(document).ready(function() {
 		showActiveTooltip: false,
 		slidesNavigation: false,
 		slidesNavPosition: 'bottom',
+		slidesNavColor: '#333',
 
 		//Scrolling
 		css3: true,
@@ -460,6 +461,8 @@ $('#fullpage').fullpage({
 - `slidesNavigation`: (default `false`) If set to `true` it will show a navigation bar made up of small circles for each landscape slider on the site.
 
 - `slidesNavPosition`: (default `bottom`) Defines the position for the landscape navigation bar for sliders. Admits `top` and `bottom` as values. You may want to modify the CSS styles to determine the distance from the top or bottom as well as any other style such as color.
+
+- `slidesNavColor`: (default `#333`) Defines the CSS color for the small circles in the landscape navigation bar.
 
 - `scrollOverflow`: (default `false`) (not compatible with IE 8) defines whether or not to create a scroll for the section/slide in case its content is bigger than the height of it. When set to `true`, your content will be wrapped by the plugin. Consider using delegation or load your other scripts in the `afterRender` callback.
 In case of setting it to `true`, it requires the vendor library [`scrolloverflow.min.js`](https://github.com/alvarotrigo/fullPage.js/blob/master/vendors/scrolloverflow.min.js). This file has to be loaded before the fullPage.js plugin.

--- a/examples/navigationH.html
+++ b/examples/navigationH.html
@@ -71,6 +71,7 @@
 				anchors: ['firstPage', 'secondPage', '3rdPage'],
 				sectionsColor: ['#8FB98B', '#DE564B', '#EAE1C0'],
 				slidesNavigation: true,
+				slidesNavColor: '#606'
 			});
 		});
 	</script>
@@ -138,18 +139,25 @@
 				</p>
 			</div>
 		</div>
-
 	    <div class="slide" id="slide2" data-anchor="slide2">
-			<h1>Slide 2</h1>
+			<div class="intro">
+				<h1>Colorful</h1>
+				<p>
+					You can even give the dots a custom color.
+				</p>
+			</div>
 		</div>
-
-		<div class="slide" id="slide3" data-anchor="slide3">
+	    <div class="slide" id="slide3" data-anchor="slide3">
 			<h1>Slide 3</h1>
-		</div>	<div class="slide" id="slide3" data-anchor="slide3">
+		</div>
+		<div class="slide" id="slide4" data-anchor="slide4">
 			<h1>Slide 4</h1>
 		</div>
-		<div class="slide" id="slide3" data-anchor="slide3">
+		<div class="slide" id="slide5" data-anchor="slide5">
 			<h1>Slide 5</h1>
+		</div>
+		<div class="slide" id="slide6" data-anchor="slide6">
+			<h1>Slide 6</h1>
 		</div>
 	</div>
 	<div class="section" id="section2">

--- a/examples/navigationV.html
+++ b/examples/navigationV.html
@@ -67,10 +67,11 @@
 		$(document).ready(function() {
 			$('#fullpage').fullpage({
 				anchors: ['firstPage', 'secondPage', '3rdPage'],
-				sectionsColor: ['#C63D0F', '#1BBC9B', '#7E8F7C'],
+				sectionsColor: ['#C63D0F', '#1BBC9B', '#7E8F7C', '#b3a6a1'],
 				navigation: true,
 				navigationPosition: 'right',
-				navigationTooltips: ['First page', 'Second page', 'Third and last page']
+				navigationTooltips: ['First page', 'Second page', 'Third page', 'Fourth and last page'],
+				navigationColor: '#606'
 			});
 		});
 	</script>
@@ -133,7 +134,7 @@
 			<div class="intro">
 				<h1>Clickable</h1>
 				<p>
-					You can even click on the navigation and jump directly to another section.
+					You can click on the navigation and jump directly to another section.
 				</p>
 			</div>
 		</div>
@@ -144,6 +145,14 @@
 
 	</div>
 	<div class="section" id="section2">
+		<div class="intro">
+			<h1>Colorful</h1>
+			<p>
+				You can even give the dots a custom color.
+			</p>
+		</div>
+	</div>
+	<div class="section" id="section3">
 		<div class="intro">
 			<h1>Enjoy it</h1>
 		</div>

--- a/jquery.fullPage.js
+++ b/jquery.fullPage.js
@@ -111,6 +111,7 @@
             showActiveTooltip: false,
             slidesNavigation: false,
             slidesNavPosition: 'bottom',
+            slidesNavColor: '#333',
             scrollBar: false,
             hybrid: false,
 
@@ -2312,8 +2313,13 @@
             //top or bottom
             nav.addClass(options.slidesNavPosition);
 
+            var span = $('<span></span>');
+            if(options.slidesNavColor){
+                span.css({ background: options.slidesNavColor });
+            }
+
             for(var i=0; i< numSlides; i++){
-                nav.find('ul').append('<li><a href="#"><span></span></a></li>');
+                nav.find('ul').append('<li><a href="#">' + span.prop('outerHTML') + '</a></li>');
             }
 
             //centering it

--- a/jquery.fullPage.js
+++ b/jquery.fullPage.js
@@ -107,6 +107,7 @@
             navigation: false,
             navigationPosition: 'right',
             navigationTooltips: [],
+            navigationColor: '#333',
             showActiveTooltip: false,
             slidesNavigation: false,
             slidesNavPosition: 'bottom',
@@ -808,13 +809,18 @@
                 return options.showActiveTooltip ? SHOW_ACTIVE_TOOLTIP + ' ' + options.navigationPosition : options.navigationPosition;
             });
 
+            var span = $('<span></span>');
+            if (options.navigationColor){
+                span.css({ background: options.navigationColor });
+            }
+
             for (var i = 0; i < $(SECTION_SEL).length; i++) {
                 var link = '';
                 if (options.anchors.length) {
                     link = options.anchors[i];
                 }
 
-                var li = '<li><a href="#' + link + '"><span></span></a>';
+                var li = '<li><a href="#' + link + '">' + span.prop('outerHTML') + '</a>';
 
                 // Only add tooltip if needed (defined by user)
                 var tooltip = options.navigationTooltips[i];


### PR DESCRIPTION
This change adds colors to the vertical and horizontal dots. Such a feature is necessary if the color of one of the sections or slides that overlaps with the dots does not really work with the default color. For example, the current default dark gray may not look well on a dark background.