### PR TITLE
add simple e2e tests using Cypress

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .idea
 bower_components/
 /node_modules
+cypress/videos

--- a/cypress.json
+++ b/cypress.json
@@ -1,0 +1,3 @@
+{
+  "baseUrl": "http://localhost:4600"
+}

--- a/cypress/fixtures/example.json
+++ b/cypress/fixtures/example.json
@@ -1,0 +1,5 @@
+{
+  "name": "Using fixtures to represent data",
+  "email": "hello@cypress.io",
+  "body": "Fixtures are a great way to mock data for responses to routes"
+}

--- a/cypress/integration/simple_spec.js
+++ b/cypress/integration/simple_spec.js
@@ -1,0 +1,67 @@
+import { Arrows, slide, checkActiveSlide, activeSlide } from '../support'
+
+describe('simple example', () => {
+  beforeEach(() => {
+    cy.visit('/examples/simple')
+    cy.get('#fullpage').should('be.visible')
+  })
+
+  it('loads', () => {
+    cy.contains('fullPage.js')
+  })
+
+  it('hides second page', () => {
+    cy.contains('Only text').should('not.be', 'visible')
+  })
+
+  it('goes down to second slide', () => {
+    cy.document().its('body').trigger('keydown', { which: Arrows.down })
+    cy.contains('.section', 'Only text').should('have.class', 'active')
+  })
+
+  it('goes down to 4th slide', () => {
+    slide.down()
+    slide.down()
+    slide.down()
+    slide.down()
+    checkActiveSlide('Just the simplest demo ever')
+  })
+
+  it('does not have left or right arrows on the first slide', () => {
+    activeSlide().find('.fp-prev').should('not.exist')
+    activeSlide().find('.fp-next').should('not.exist')
+  })
+
+  it('shows left and right arrows', () => {
+    slide.down()
+    checkActiveSlide('Only text')
+    activeSlide().find('.fp-prev').should('be.visible')
+    activeSlide().find('.fp-next').should('be.visible')
+  })
+
+  it('goes horizontally', () => {
+    slide.down()
+    checkActiveSlide('Only text')
+    slide.right()
+    checkActiveSlide('And text')
+    slide.right()
+    checkActiveSlide('And more text')
+    slide.left()
+    checkActiveSlide('And text')
+    slide.down()
+    checkActiveSlide('No wraps, no extra markup')
+  })
+
+  it('loops horizontally', () => {
+    slide.down()
+    checkActiveSlide('Only text')
+    slide.right()
+    checkActiveSlide('And text')
+    slide.right()
+    checkActiveSlide('And more text')
+    slide.right()
+    checkActiveSlide('Simple Demo')
+    slide.right()
+    checkActiveSlide('Only text')
+  })
+})

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -1,0 +1,17 @@
+// ***********************************************************
+// This example plugins/index.js can be used to load plugins
+//
+// You can change the location of this file or turn off loading
+// the plugins file with the 'pluginsFile' configuration option.
+//
+// You can read more here:
+// https://on.cypress.io/plugins-guide
+// ***********************************************************
+
+// This function is called when a project is opened or re-opened (e.g. due to
+// the project's config changing)
+
+module.exports = (on, config) => {
+  // `on` is used to hook into various events Cypress emits
+  // `config` is the resolved Cypress config
+}

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,0 +1,25 @@
+// ***********************************************
+// This example commands.js shows you how to
+// create various custom commands and overwrite
+// existing commands.
+//
+// For more comprehensive examples of custom
+// commands please read more here:
+// https://on.cypress.io/custom-commands
+// ***********************************************
+//
+//
+// -- This is a parent command --
+// Cypress.Commands.add("login", (email, password) => { ... })
+//
+//
+// -- This is a child command --
+// Cypress.Commands.add("drag", { prevSubject: 'element'}, (subject, options) => { ... })
+//
+//
+// -- This is a dual command --
+// Cypress.Commands.add("dismiss", { prevSubject: 'optional'}, (subject, options) => { ... })
+//
+//
+// -- This is will overwrite an existing command --
+// Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -1,0 +1,55 @@
+// ***********************************************************
+// This example support/index.js is processed and
+// loaded automatically before your test files.
+//
+// This is a great place to put global configuration and
+// behavior that modifies Cypress.
+//
+// You can change the location of this file or turn off
+// automatically serving support files with the
+// 'supportFile' configuration option.
+//
+// You can read more here:
+// https://on.cypress.io/configuration
+// ***********************************************************
+
+// Import commands.js using ES2015 syntax:
+import './commands'
+
+// Alternatively you can use CommonJS syntax:
+// require('./commands')
+
+export const Arrows = {
+  up: 38,
+  down: 40,
+  left: 37,
+  right: 39
+}
+
+function triggerArrow (which) {
+  cy.document().its('body').trigger('keydown', { which }).wait(1000)
+}
+
+export const slide = {
+  down () {
+    triggerArrow(Arrows.down)
+  },
+
+  up () {
+    triggerArrow(Arrows.up)
+  },
+
+  left () {
+    triggerArrow(Arrows.left)
+  },
+
+  right () {
+    triggerArrow(Arrows.right)
+  }
+}
+
+export function checkActiveSlide (text) {
+  cy.contains('.section', text).should('have.class', 'active')
+}
+
+export const activeSlide = () => cy.get('.section.active')

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   "homepage": "https://github.com/alvarotrigo/fullPage.js",
   "namespace": "$.fn.fullpage",
   "devDependencies": {
+    "cypress": "^1.1.4",
     "gulp": "^3.9.0",
     "gulp-clean-css": "^2.0.8",
     "gulp-rename": "^1.2.2",


### PR DESCRIPTION
1- Make sure to commit it to the `dev` branch!
2- Read https://github.com/alvarotrigo/fullPage.js/wiki/Contributing-to-fullpage.js

This branch adds end to end tests with a GUI using [cypress.io](github.com/cypress-io/cypress) test runner. 

Example test
```js
it('loops horizontally', () => {
    slide.down()
    checkActiveSlide('Only text')
    slide.right()
    checkActiveSlide('And text')
    slide.right()
    checkActiveSlide('And more text')
    slide.right()
    checkActiveSlide('Simple Demo')
    slide.right()
    checkActiveSlide('Only text')
  })
```

Example GUI during testing

<img width="1276" alt="screen shot 2017-12-08 at 12 17 01 pm" src="https://user-images.githubusercontent.com/2212006/33777182-d375a2a6-dc11-11e7-947d-4ecbff076a54.png">

Test run recording (built-in) at https://youtu.be/Yzodhs8MayA

<iframe width="1280" height="720" src="https://www.youtube.com/embed/Yzodhs8MayA?rel=0" frameborder="0" gesture="media" allow="encrypted-media" allowfullscreen></iframe>

For more info about this E2E test runner

- https://www.cypress.io/
- https://github.com/cypress-io/cypress