### PR TITLE
Tell people to load the scrollOverflow script after jQuery

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,7 +459,7 @@ $('#fullpage').fullpage({
 - `slidesNavPosition`: (default `bottom`) Defines the position for the landscape navigation bar for sliders. Admits `top` and `bottom` as values. You may want to modify the CSS styles to determine the distance from the top or bottom as well as any other style such as color.
 
 - `scrollOverflow`: (default `false`) (not compatible with IE 8) defines whether or not to create a scroll for the section/slide in case its content is bigger than the height of it. When set to `true`, your content will be wrapped by the plugin. Consider using delegation or load your other scripts in the `afterRender` callback.
-In case of setting it to `true`, it requires the vendor library [`scrolloverflow.min.js`](https://github.com/alvarotrigo/fullPage.js/blob/master/vendors/scrolloverflow.min.js). This file has to be loaded before the fullPage.js plugin.
+In case of setting it to `true`, it requires the vendor library [`scrolloverflow.min.js`](https://github.com/alvarotrigo/fullPage.js/blob/master/vendors/scrolloverflow.min.js). This file has to be loaded before the fullPage.js plugin, but after jQuery.
 For example:
 
 ```html


### PR DESCRIPTION
I had a long-standing issue where `scrollOverflow: true` was not doing anything. After a lot of time debugging, I eventually found that loading it after jQuery solved the issue. I think that it is very important for other people to know this so that they don't have to go through the pointless journey I went through.

I feel really stupid now