### PR TITLE
Updating gulp-uglify to latest version as well as changing deprecated…

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -31,7 +31,9 @@ gulp.task('js', function() {
         .pipe(sourcemaps.init())
         .pipe(gulp.dest('./dist'))
         .pipe(uglify({
-            preserveComments: 'license'
+            output: {
+                comments: 'some'
+            }
         }))
         .pipe(rename({suffix: '.min'}))
         .pipe(sourcemaps.write('.'))
@@ -43,7 +45,9 @@ gulp.task('scrolloverflow', function() {
         .pipe(sourcemaps.init())
         .pipe(gulp.dest('./vendors'))
         .pipe(uglify({
-            preserveComments: 'license'
+            output: {
+                comments: 'some'
+            }
         }))
         .pipe(rename({suffix: '.min'}))
         .pipe(sourcemaps.write('.'))
@@ -54,7 +58,9 @@ gulp.task('scrolloverflow', function() {
 gulp.task('extensions', function() {
     gulp.src('./jquery.fullpage.extensions.js')
         .pipe(uglify({
-            preserveComments: 'license'
+            output: {
+                comments: 'some'
+            }
         }))
         .pipe(rename({suffix: '.min'}))
         .pipe(gulp.dest('./dist'));

--- a/package.json
+++ b/package.json
@@ -47,6 +47,6 @@
     "gulp-rename": "^1.2.2",
     "gulp-sass": "^2.0.4",
     "gulp-sourcemaps": "^1.6.0",
-    "gulp-uglify": "^2.1.2"
+    "gulp-uglify": "^3.0.0"
   }
 }


### PR DESCRIPTION
… "preserveComments" with new syntax. This solves the problem of minified versions of fullpagejs from being compatible with webpack bundling.

1- Make sure to commit it to the `dev` branch!
2- Read https://github.com/alvarotrigo/fullPage.js/wiki/Contributing-to-fullpage.js