### PR TITLE
Remove keydown handler on destroy

### DIFF
--- a/jquery.fullPage.js
+++ b/jquery.fullPage.js
@@ -2724,6 +2724,7 @@
                 .off('resize', resizeHandler);
 
             $document
+                .off('keydown', keydownHandler)
                 .off('click touchstart', SECTION_NAV_SEL + ' a')
                 .off('mouseenter', SECTION_NAV_SEL + ' li')
                 .off('mouseleave', SECTION_NAV_SEL + ' li')


### PR DESCRIPTION
This is made necessary as the fix for  #1237, by adding the `onTab` function is not reverted on destroying fullpage.js plugin. Consequently, this was breaking tab functionality when the plugin is no longer active.