### PR TITLE
Remove keyup handler on destroy

### DIFF
--- a/jquery.fullPage.js
+++ b/jquery.fullPage.js
@@ -1,5 +1,5 @@
 /*!
- * fullPage 2.9.6
+ * fullPage 2.9.7
  * https://github.com/alvarotrigo/fullPage.js
  * @license MIT licensed
  *

--- a/jquery.fullPage.js
+++ b/jquery.fullPage.js
@@ -2725,6 +2725,7 @@
 
             $document
                 .off('keydown', keydownHandler)
+                .off('keyup', keyUpHandler)
                 .off('click touchstart', SECTION_NAV_SEL + ' a')
                 .off('mouseenter', SECTION_NAV_SEL + ' li')
                 .off('mouseleave', SECTION_NAV_SEL + ' li')


### PR DESCRIPTION
1. Complementing #3124, unbinding the keyup handler as well to revert to the original state on destroying fullpage.js.
2. Version bump to 2.9.7