### PR TITLE
Use jquery height to set wrapper height, instead on relying on style …

### DIFF
--- a/jquery.fullPage.js
+++ b/jquery.fullPage.js
@@ -2254,7 +2254,8 @@
         function addTableClass(element){
             //In case we are styling for the 2nd time as in with reponsiveSlides
             if(!element.hasClass(TABLE)){
-                element.addClass(TABLE).wrapInner('<div class="' + TABLE_CELL + '" style="height:' + getTableHeight(element) + 'px;" />');
+                var wrapper = $('<div class="' + TABLE_CELL + '" />').height(getTableHeight(element));
+                element.addClass(TABLE).wrapInner(wrapper);
             }
         }
 


### PR DESCRIPTION
Using inline styles violates style-src CSP rule (unless you set `unsafe-inline`).
Set the wrapper height using `.height(value)` instead of setting it using `style` attribute.
#3170