### PR TITLE
Prevent jQuery adapter from loading when fullpage is not global

### DIFF
--- a/src/fullpage.js
+++ b/src/fullpage.js
@@ -3845,7 +3845,7 @@
 /**
  * jQuery adapter for fullPage.js 3.0.0
  */
-if(window.jQuery){
+if(window.jQuery && window.fullpage){
     (function ($, fullpage) {
         'use strict';
 


### PR DESCRIPTION
If you import fullpage.js into a module without a jQuery dependency and bundled with webpack.

When using the bundle in a page that has jQuery as a global, it will expect fullpage to exist as a global which can cause an error.

By adding window.jQuery && window.fullpage to the conditional it will prevent the adapter from loading unless fullpage is a global.