### PR TITLE
Add safeguards in onTab

### DIFF
--- a/src/fullpage.js
+++ b/src/fullpage.js
@@ -2070,10 +2070,7 @@
             function preventAndFocusFirst(e){
                 preventDefault(e);
                 const firstFocusableElement = focusableElements[0];
-                if (firstFocusableElement) {
-                    firstFocusableElement.focus();
-                }
-                return;
+                return firstFocusableElement ? firstFocusableElement.focus() : null;
             }
 
             //is there an element with focus?

--- a/src/fullpage.js
+++ b/src/fullpage.js
@@ -2069,7 +2069,11 @@
 
             function preventAndFocusFirst(e){
                 preventDefault(e);
-                return focusableElements[0].focus();
+                const firstFocusableElement = focusableElements[0];
+                if (firstFocusableElement) {
+                    firstFocusableElement.focus();
+                }
+                return;
             }
 
             //is there an element with focus?


### PR DESCRIPTION
Checks for undefined before calling focus() on an element

I'm facing a problem in my React app that uses fullpage.js. Whenever I press the Tab key, the keydown handler inside fullPage fails and prevents my own keydown handlers to work. In this pull request, I added a simple check that prevents calling `.focus()` on `undefined`.