### PR TITLE
Bugfix #3403: autoscrolling and scrolloverflow are exclusive.

### DIFF
--- a/src/fullpage.js
+++ b/src/fullpage.js
@@ -3137,8 +3137,9 @@
                 showError('warn', 'Option `loopTop/loopBottom` is mutually exclusive with `continuousVertical`; `continuousVertical` disabled');
             }
 
-            if(options.scrollBar && options.scrollOverflow){
-                showError('warn', 'Option `scrollBar` is mutually exclusive with `scrollOverflow`. Sections with scrollOverflow might not work well in Firefox');
+            if(options.scrollOverflow &&
+               (options.scrollBar || options.autoScrolling){
+                showError('warn', 'Options scrollBar:true and autoScrolling:true are mutually exclusive with scrollOverflow:true. Sections with scrollOverflow might not work well in Firefox');
             }
 
             if(options.continuousVertical && (options.scrollBar || !options.autoScrolling)){


### PR DESCRIPTION
Added an extra option to display a warning the user that autoScrolling and scrollOverflow are exclusive.

1- Make sure to commit it to the `dev` branch!
2- Read https://github.com/alvarotrigo/fullPage.js/wiki/Contributing-to-fullpage.js