### PR TITLE
Bugfix: loss attached events on unwrapping

### DIFF
--- a/src/fullpage.js
+++ b/src/fullpage.js
@@ -3129,7 +3129,7 @@
             [TABLE_CELL_SEL, SLIDES_CONTAINER_SEL,SLIDES_WRAPPER_SEL].forEach(function(selector){
                 $(selector, container).forEach(function(item){
                     //unwrap not being use in case there's no child element inside and its just text
-                    item.outerHTML = item.innerHTML;
+                    unwrap(item);
                 });
             });
 
@@ -3649,6 +3649,23 @@
     }
 
     /**
+    * Usage:
+    * unwrap(document.querySelector('#pepe'));
+    * unwrap(element);
+    *
+    * https://jsfiddle.net/szjt0hxq/1/
+    *
+    */
+    function unwrap(wrapper) {
+        var wrapperContent = document.createDocumentFragment();
+        while (wrapper.firstChild) {
+            wrapperContent.appendChild(wrapper.firstChild);
+        }
+
+        wrapper.parentNode.replaceChild(wrapperContent, wrapper);
+    }
+
+    /**
     * http://stackoverflow.com/questions/22100853/dom-pure-javascript-solution-to-jquery-closest-implementation
     * Returns the element or `false` if there's none
     */
@@ -3881,6 +3898,7 @@
         wrap: wrap,
         wrapAll: wrapAll,
         wrapInner: wrapInner,
+        unwrap: unwrap,
         closest: closest,
         after: after,
         before: before,

--- a/vendors/scrolloverflow.js
+++ b/vendors/scrolloverflow.js
@@ -2504,8 +2504,8 @@ if ( typeof module != 'undefined' && module.exports ) {
                     scrollable.fp_iscrollInstance = null;
 
                     //unwrapping...
-                    $('.fp-scroller', element)[0].outerHTML = $('.fp-scroller', element)[0].innerHTML;
-                    $(SCROLLABLE_SEL, element)[0].outerHTML = $(SCROLLABLE_SEL, element)[0].innerHTML;
+                    fp_utils.unwrap($('.fp-scroller', element)[0]);
+                    fp_utils.unwrap($(SCROLLABLE_SEL, element)[0]);
                 }
             },
 


### PR DESCRIPTION
There are two bugs with the same root cause that current PR fix:
Assuming you have elements inside your section with attached event listeners (e.g. in case of using angular it can be ng-bind).
1) After initializing FullPage your section content will be wrapped by additional HTML markup.
If you call "destroy('all')" this markup will be removed and content returned to original state. But actually all DOM elements will be recreated, because innerHTML/outerHTML properties are used for unwrapping.
Hence all listeners won't work after that. 
2) Assuming you are using scrolloverflow with FullPage. Your section content will be wrapped by scrolloverflow markup. Now you resize your window to the size when scrollbar should be hidden. As result scrolloverflow markup will be removed. The same method is using for unwrapping section content, hence same bug is here. 
  
Solution:
Created unwrap function that keeps existing DOM objects (instead of recreating them using innerHTML) to save all event listeners attached to them;
Used unwrap function in "fullpage - destroy all" and in "scrolloverflow - destroy".