### PR TITLE
Add conditional statement before remove eventListener

### DIFF
--- a/src/fullpage.js
+++ b/src/fullpage.js
@@ -2893,8 +2893,10 @@
                     $body.removeEventListener(events.touchmove, preventBouncing, {passive: false});
                 }
 
-                $(WRAPPER_SEL)[0].removeEventListener(events.touchstart, touchStartHandler);
-                $(WRAPPER_SEL)[0].removeEventListener(events.touchmove, touchMoveHandler, {passive: false});
+                if($(WRAPPER_SEL)[0]){
+                  $(WRAPPER_SEL)[0].removeEventListener(events.touchstart, touchStartHandler);
+                  $(WRAPPER_SEL)[0].removeEventListener(events.touchmove, touchMoveHandler, {passive: false});
+                }
             }
         }
 


### PR DESCRIPTION
1- Make sure to commit it to the 'dev' branch!
2- Read https://github.com/alvarotrigo/fullPage.js/wiki/Contributing-to-fullpage.js

In applications that generate and destroy templates dynamically, as like MeteorJS,

templates are destroyed by template engine. 

When fullpage_api.destroy('all') is called, current templates are already removed. 

it makes undefined Object error.

To avoid this, I added just conditional statement $(WRAPPER_SEL)[0] is still exists or not.

(I found this issue when I test laptop device that has touch screen )

Thank you!
