### PR TITLE
Fixed issue #3527 ScrollOverflow event order

### DIFF
--- a/src/fullpage.js
+++ b/src/fullpage.js
@@ -2862,12 +2862,12 @@
 
 
             if(support == 'DOMMouseScroll'){
-                document[ _addEventListener ](prefix + 'MozMousePixelScroll', MouseWheelHandler, false);
+                document[ _addEventListener ](prefix + 'MozMousePixelScroll', MouseWheelHandler, true);
             }
 
             //handle MozMousePixelScroll in older Firefox
             else{
-                document[ _addEventListener ](prefix + support, MouseWheelHandler, false);
+                document[ _addEventListener ](prefix + support, MouseWheelHandler, true);
             }
         }
 

--- a/vendors/scrolloverflow.js
+++ b/vendors/scrolloverflow.js
@@ -2175,9 +2175,9 @@ if ( typeof module != 'undefined' && module.exports ) {
         * https://github.com/cubiq/iscroll/issues/1036
         */
         IScroll.prototype.wheelOn = function () {
-            this.wrapper.addEventListener('wheel', this);
-            this.wrapper.addEventListener('mousewheel', this);
-            this.wrapper.addEventListener('DOMMouseScroll', this);
+            this.wrapper.addEventListener('wheel', this, false);
+            this.wrapper.addEventListener('mousewheel', this, false);
+            this.wrapper.addEventListener('DOMMouseScroll', this, false);
         };
 
         /*


### PR DESCRIPTION
### Description
Using fullpage.js 2.9.7, I found an issue with Scrolloverflow. The issue can be reproduced on the demo page in 3.0.2. https://alvarotrigo.com/fullPage/examples/scrolling.html

When scrolling down inside a long section with a wheel, the last wheel event fires a section jump instead of simply scrolling inside of the current section. On the demo page, if you scroll down the first page you cannot read "Ea zril aliquip euismod sed." without jumping to the next section.

### Root cause
It is due to the check line 1068 of jquery.fullPage.js (2.9.7)
`options.scrollOverflowHandler.isScrolled(check, scrollable)`
 being performed after the wheel event is resolved in scrolloverflow.js. It results that the check to see if the section is scrolled is performed with the "future" scrolling coordinates, not the current one.

### Proposed fix
Make the wheel events attached to the fp-scrollable dom elements not capture the event in scrolloverflow.js
```
IScroll.prototype.wheelOn = function () 
    this.wrapper.addEventListener('wheel', this, false); /* Event is fired only in the bubbling phase */  
    this.wrapper.addEventListener('mousewheel', this, false);   /* Event is fired only in the bubbling phase */ 
    this.wrapper.addEventListener('DOMMouseScroll', this, false);  /* Event is fired only in the bubbling phase */ 
};
```

Make sure the wheel event attached to document are fired in fullpage.js
```
function addMouseWheelHandler(){
            var prefix = '';
            var _addEventListener;

            if (window.addEventListener){
                _addEventListener = "addEventListener";
            }else{
                _addEventListener = "attachEvent";
                prefix = 'on';
            }

             // detect available wheel event
            var support = 'onwheel' in document.createElement('div') ? 'wheel' : // Modern browsers support "wheel"
                      document.onmousewheel !== undefined ? 'mousewheel' : // Webkit and IE support at least "mousewheel"
                      'DOMMouseScroll'; // let's assume that remaining browsers are older Firefox


            if(support == 'DOMMouseScroll'){
                document[ _addEventListener ](prefix + 'MozMousePixelScroll', MouseWheelHandler, true); /* Event is fired in the capturing phase */
            }

            //handle MozMousePixelScroll in older Firefox
            else{
                document[ _addEventListener ](prefix + support, MouseWheelHandler, true); /* Event is fired in the capturing phase */
            }
        }```