### PR TITLE
Fixes #3613

### DIFF
--- a/src/fullpage.js
+++ b/src/fullpage.js
@@ -913,7 +913,11 @@
 
             //moving the menu outside the main container if it is inside (avoid problems with fixed positions when using CSS3 tranforms)
             if(options.menu && options.css3 && closest($(options.menu)[0], WRAPPER_SEL) != null){
-                $body.appendChild($(options.menu)[0]);
+                $(options.menu).forEach(function(domElement, i) {
+                    var menu = $(options.menu)[i];
+
+                    $body.appendChild(menu);
+                });
             }
         }
 
@@ -2554,11 +2558,14 @@
         * Activating the website main menu elements according to the given slide name.
         */
         function activateMenuElement(name){
-            var menu = $(options.menu)[0];
-            if(options.menu && menu != null){
-                removeClass($(ACTIVE_SEL, menu), ACTIVE);
-                addClass($('[data-menuanchor="'+name+'"]', menu), ACTIVE);
-            }
+            $(options.menu).forEach(function(domElement, i) {
+                var menu = $(options.menu)[i];
+
+                if(options.menu && menu != null){
+                    removeClass($(ACTIVE_SEL, menu), ACTIVE);
+                    addClass($('[data-menuanchor="'+name+'"]', menu), ACTIVE);
+                }
+            });
         }
 
         /**

--- a/src/fullpage.js
+++ b/src/fullpage.js
@@ -914,9 +914,8 @@
             //moving the menu outside the main container if it is inside (avoid problems with fixed positions when using CSS3 tranforms)
             if(options.menu && options.css3 && closest($(options.menu)[0], WRAPPER_SEL) != null){
                 $(options.menu).forEach(function(domElement, i) {
-                    var menu = $(options.menu)[i];
 
-                    $body.appendChild(menu);
+                    $body.appendChild(domElement);
                 });
             }
         }
@@ -2559,7 +2558,7 @@
         */
         function activateMenuElement(name){
             $(options.menu).forEach(function(domElement, i) {
-                var menu = $(options.menu)[i];
+                var menu = domElement;
 
                 if(options.menu && menu != null){
                     removeClass($(ACTIVE_SEL, menu), ACTIVE);

--- a/tests/index.html
+++ b/tests/index.html
@@ -30,7 +30,7 @@
     #menu-two{
         position:fixed;
         top:0;
-        right:0;
+        left:500px;
         height: 40px;
         z-index: 70;
         width: 100%;

--- a/tests/index.html
+++ b/tests/index.html
@@ -27,6 +27,16 @@
         padding: 0;
         margin:0;
     }
+    #menu-two{
+        position:fixed;
+        top:0;
+        right:0;
+        height: 40px;
+        z-index: 70;
+        width: 100%;
+        padding: 0;
+        margin:0;
+    }
     .normalscroll{
         overflow: scroll;
         height: 300px;
@@ -43,7 +53,14 @@
 <div id="qunit"></div>
 <div id="qunit-fixture">
 
-    <ul id="menu">
+    <ul id="menu" class="menu">
+        <li data-menuanchor="page1"><a href="#page1">One</a></li>
+        <li data-menuanchor="page2"><a href="#page2">Two</a></li>
+        <li data-menuanchor="page3"><a href="#page3">Three</a></li>
+        <li data-menuanchor="page4"><a href="#page4">Four</a></li>
+    </ul>
+
+    <ul id="menu-two" class="menu">
         <li data-menuanchor="page1"><a href="#page1">One</a></li>
         <li data-menuanchor="page2"><a href="#page2">Two</a></li>
         <li data-menuanchor="page3"><a href="#page3">Three</a></li>
@@ -350,7 +367,7 @@
   crossorigin="anonymous"></script>
 
 <script type="text/javascript" src="https://code.jquery.com/qunit/qunit-2.5.1.js"></script>
-<script type="text/javascript" src="../src/fullpage.extensions.js"></script>
+<script type="text/javascript" src="../src/fullpage.js"></script>
 <script type="text/javascript">
 
 </script>

--- a/tests/unit/menu.js
+++ b/tests/unit/menu.js
@@ -54,13 +54,22 @@ QUnit.test('Testing menu `active` class when auto scrolling', function(assert) {
     var id = '#fullpage';
     var FP = initFullpageNew(id, Object.assign({}, allBasicOptions, {menu: '#menu'}));
 
+    // first menu
     assert.equal($('#menu').find('.active[data-menuanchor]').index(), 0, 'We expect item 1 to be active');
     assert.equal($('#menu').find('.active[data-menuanchor]').length, 1, 'We expect a single item to be active');
 
+    // second menu
+    assert.equal($('#menu-two').find('.active[data-menuanchor]').index(), 0, 'We expect item 1 to be active');
+    assert.equal($('#menu-two').find('.active[data-menuanchor]').length, 1, 'We expect a single item to be active');
+
     for(var i = 1; i<4; i++){
         FP.moveSectionDown();
+        // first menu
         assert.equal($('#menu').find('.active[data-menuanchor]').index(), i, 'We expect item ' + (i +1) +' to be active');
         assert.equal($('#menu').find('.active[data-menuanchor]').length, 1, 'We expect a single item to be active');
+        // second menu
+        assert.equal($('#menu-two').find('.active[data-menuanchor]').index(), i, 'We expect item ' + (i +1) +' to be active');
+        assert.equal($('#menu-two').find('.active[data-menuanchor]').length, 1, 'We expect a single item to be active');
     }
 });
 
@@ -68,13 +77,21 @@ QUnit.test('Testing menu `active` class when auto scrolling and sliding horizont
     var id = '#fullpage-moveSlideRight';
     var FP = initFullpageNew(id, Object.assign({}, allBasicOptions, {menu: '#menu'}));
 
+    // first menu
     assert.equal($('#menu').find('.active[data-menuanchor]').index(), 0, 'We expect item 1 to be active');
     assert.equal($('#menu').find('.active[data-menuanchor]').length, 1, 'We expect a single item to be active');
+    // second menu
+    assert.equal($('#menu-two').find('.active[data-menuanchor]').index(), 0, 'We expect item 1 to be active');
+    assert.equal($('#menu-two').find('.active[data-menuanchor]').length, 1, 'We expect a single item to be active');
 
     for(var i = 1; i<4; i++){
         FP.moveSlideRight();
+        // first menu
         assert.equal($('#menu').find('.active[data-menuanchor]').index(), 0, 'We expect item 1 to be active');
         assert.equal($('#menu').find('.active[data-menuanchor]').length, 1, 'We expect a single item to be active');
+        // second menu
+        assert.equal($('#menu-two').find('.active[data-menuanchor]').index(), 0, 'We expect item 1 to be active');
+        assert.equal($('#menu-two').find('.active[data-menuanchor]').length, 1, 'We expect a single item to be active');
     }
 });
 
@@ -82,16 +99,27 @@ QUnit.test('Testing menu `active` class when scrolling & autoScrolling:false', f
     var id = '#fullpage';
     var FP = initFullpageNew(id, Object.assign({}, allBasicOptions, {autoScrolling:false, menu: '#menu'}));
 
+    // first menu
     assert.equal($('#menu').find('.active[data-menuanchor]').index(), 0, 'We expect item 1 to be active');
+    // second menu
+    assert.equal($('#menu-two').find('.active[data-menuanchor]').index(), 0, 'We expect item 1 to be active');
 
     simulateScroll(window.innerHeight);
+    // first menu
     assert.equal($('#menu').find('.active[data-menuanchor]').index(), 1, 'We expect item 2 to be active');
     assert.equal($('#menu').find('.active[data-menuanchor]').length, 1, 'We expect a single item to be active');
+    // second menu
+    assert.equal($('#menu-two').find('.active[data-menuanchor]').index(), 1, 'We expect item 2 to be active');
+    assert.equal($('#menu-two').find('.active[data-menuanchor]').length, 1, 'We expect a single item to be active');
 
 
     simulateScroll(window.innerHeight * 3);
+    // first menu
     assert.equal($('#menu').find('.active[data-menuanchor]').index(), 3, 'We expect item 4 to be active');
     assert.equal($('#menu').find('.active[data-menuanchor]').length, 1, 'We expect a single item to be active');
+    // second menu
+    assert.equal($('#menu-two').find('.active[data-menuanchor]').index(), 3, 'We expect item 4 to be active');
+    assert.equal($('#menu-two').find('.active[data-menuanchor]').length, 1, 'We expect a single item to be active');
 });
 
 QUnit.test('Testing menu `active` class when hash change by anchor name', function(assert) {
@@ -100,15 +128,23 @@ QUnit.test('Testing menu `active` class when hash change by anchor name', functi
 
     var done = assert.async(1);
 
+    // first menu
     assert.equal($('#menu').find('.active[data-menuanchor]').index(), 0, 'We expect item 1 to be active');
     assert.equal($('#menu').find('.active[data-menuanchor]').length, 1, 'We expect a single item to be active');
+    // second menu
+    assert.equal($('#menu-two').find('.active[data-menuanchor]').index(), 0, 'We expect item 1 to be active');
+    assert.equal($('#menu-two').find('.active[data-menuanchor]').length, 1, 'We expect a single item to be active');
 
     //changing the URL won't scroll to the given section
     window.location.hash = '#page3';
 
     setTimeout(function(){
+        // first menu
         assert.equal($('#menu').find('.active[data-menuanchor]').index(), 2, 'We expect item 3 to be active');
         assert.equal($('#menu').find('.active[data-menuanchor]').length, 1, 'We expect a single item to be active');
+        // second menu
+        assert.equal($('#menu-two').find('.active[data-menuanchor]').index(), 2, 'We expect item 3 to be active');
+        assert.equal($('#menu-two').find('.active[data-menuanchor]').length, 1, 'We expect a single item to be active');
         done();
     },100);
 });
@@ -119,15 +155,23 @@ QUnit.test('Testing menu `active` class when hash change by section index', func
 
     var done = assert.async(1);
 
+    // first menu
     assert.equal($('#menu').find('.active[data-menuanchor]').index(), 0, 'We expect item 1 to be active');
     assert.equal($('#menu').find('.active[data-menuanchor]').length, 1, 'We expect a single item to be active');
+    // second menu
+    assert.equal($('#menu-two').find('.active[data-menuanchor]').index(), 0, 'We expect item 1 to be active');
+    assert.equal($('#menu-two').find('.active[data-menuanchor]').length, 1, 'We expect a single item to be active');
 
     //changing the URL won't scroll to the given section
     window.location.hash = '#3';
 
     setTimeout(function(){
+        // first menu
         assert.equal($('#menu').find('.active[data-menuanchor]').index(), 2, 'We expect item 3 to be active');
         assert.equal($('#menu').find('.active[data-menuanchor]').length, 1, 'We expect a single item to be active');
+        // second menu
+        assert.equal($('#menu-two').find('.active[data-menuanchor]').index(), 2, 'We expect item 3 to be active');
+        assert.equal($('#menu-two').find('.active[data-menuanchor]').length, 1, 'We expect a single item to be active');
         done();
     },100);
 });

--- a/tests/unit/menu.js
+++ b/tests/unit/menu.js
@@ -52,7 +52,7 @@ QUnit.test('Testing menu. Keeping it inside the library wrapper when css3:false'
 
 QUnit.test('Testing menu `active` class when auto scrolling', function(assert) {
     var id = '#fullpage';
-    var FP = initFullpageNew(id, Object.assign({}, allBasicOptions, {menu: '#menu'}));
+    var FP = initFullpageNew(id, Object.assign({}, allBasicOptions, {menu: '.menu'}));
 
     // first menu
     assert.equal($('#menu').find('.active[data-menuanchor]').index(), 0, 'We expect item 1 to be active');
@@ -75,7 +75,7 @@ QUnit.test('Testing menu `active` class when auto scrolling', function(assert) {
 
 QUnit.test('Testing menu `active` class when auto scrolling and sliding horizontally', function(assert) {
     var id = '#fullpage-moveSlideRight';
-    var FP = initFullpageNew(id, Object.assign({}, allBasicOptions, {menu: '#menu'}));
+    var FP = initFullpageNew(id, Object.assign({}, allBasicOptions, {menu: '.menu'}));
 
     // first menu
     assert.equal($('#menu').find('.active[data-menuanchor]').index(), 0, 'We expect item 1 to be active');
@@ -97,7 +97,7 @@ QUnit.test('Testing menu `active` class when auto scrolling and sliding horizont
 
 QUnit.test('Testing menu `active` class when scrolling & autoScrolling:false', function(assert) {
     var id = '#fullpage';
-    var FP = initFullpageNew(id, Object.assign({}, allBasicOptions, {autoScrolling:false, menu: '#menu'}));
+    var FP = initFullpageNew(id, Object.assign({}, allBasicOptions, {autoScrolling:false, menu: '.menu'}));
 
     // first menu
     assert.equal($('#menu').find('.active[data-menuanchor]').index(), 0, 'We expect item 1 to be active');
@@ -124,7 +124,7 @@ QUnit.test('Testing menu `active` class when scrolling & autoScrolling:false', f
 
 QUnit.test('Testing menu `active` class when hash change by anchor name', function(assert) {
     var id = '#fullpage';
-    var FP = initFullpageNew(id, Object.assign({}, allBasicOptions, {menu: '#menu'}));
+    var FP = initFullpageNew(id, Object.assign({}, allBasicOptions, {menu: '.menu'}));
 
     var done = assert.async(1);
 
@@ -151,7 +151,7 @@ QUnit.test('Testing menu `active` class when hash change by anchor name', functi
 
 QUnit.test('Testing menu `active` class when hash change by section index', function(assert) {
     var id = '#fullpage';
-    var FP = initFullpageNew(id, Object.assign({}, allBasicOptions, {menu: '#menu'}));
+    var FP = initFullpageNew(id, Object.assign({}, allBasicOptions, {menu: '.menu'}));
 
     var done = assert.async(1);
 


### PR DESCRIPTION
**Description**
In the change from v2.* to v3.* there was a regression in the code. In v2.* when providing a selector for the menu options you could provide a class selector and it would target all matched elements, in v3.* it will only target the first matched element.

**Link to isolated reproduction with no external CSS / JS**
Functionality in v2.6.6
Functionality in v3.0.4

**This PR Contains**
Passing QUnit tests describing the missing functionality
Updates to `styleMenu` and `activateMenuElement` functions to make them deal with multiple menus rather than just grabbing the first matched element from the given selector