### PR TITLE
Change transition duration independently

### DIFF
--- a/README.md
+++ b/README.md
@@ -693,7 +693,7 @@ fullpage_api.setScrollingSpeed(700);
 Defines the transition time in milliseconds.
 
 ```javascript
-fullpage_api.setTransitionSpeed(700);
+fullpage_api.setTransitionSpeed(450);
 ```
 ---
 ### destroy(type)

--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ var myFullpage = new fullpage('#fullpage', {
 	//Scrolling
 	css3: true,
 	scrollingSpeed: 700,
+	transitionSpeed: this.scrollingSpeed,
 	autoScrolling: true,
 	fitToSection: true,
 	fitToSectionDelay: 1000,
@@ -387,7 +388,9 @@ new fullpage({
 
 - `verticalCentered`: (default `true`) Vertically centering of the content within sections. When set to `true`, your content will be wrapped by the library. Consider using delegation or load your other scripts in the `afterRender` callback.
 
-- `scrollingSpeed`: (default `700`) Speed in milliseconds for the scrolling transitions.
+- `scrollingSpeed`: (default `700`) Speed in milliseconds until site is responsive to scrolling.
+
+- `transitionSpeed`: (default `scrollingSpeed`) Speed in milliseconds for the scrolling transitions.
 
 - `sectionsColor`: (default `none`) Define the CSS `background-color` property for each section.
 Example:

--- a/README.md
+++ b/README.md
@@ -683,10 +683,17 @@ fullpage_api.setRecordHistory(false);
 ```
 ---
 ### setScrollingSpeed(milliseconds)
-[Demo](http://codepen.io/alvarotrigo/pen/NqLbeY) Defines the scrolling speed in milliseconds.
+[Demo](http://codepen.io/alvarotrigo/pen/NqLbeY) Defines the time in milliseconds until site is responsive to scrolling .
 
 ```javascript
 fullpage_api.setScrollingSpeed(700);
+```
+---
+### setTransitionSpeed(milliseconds)
+Defines the transition time in milliseconds.
+
+```javascript
+fullpage_api.setTransitionSpeed(700);
 ```
 ---
 ### destroy(type)

--- a/src/fullpage.js
+++ b/src/fullpage.js
@@ -121,6 +121,7 @@
 
             //scrolling
             css3: true,
+            transitionSpeed: this.scrollingSpeed,
             scrollingSpeed: 700,
             autoScrolling: true,
             fitToSection: true,
@@ -343,6 +344,13 @@
         }
 
         /**
+        * Defines the transition speed
+        */
+        function setTransitionSpeed(value, type){
+            setVariableState('transitionSpeed', value, type);
+        }
+
+        /**
         * Sets fitToSection
         */
         function setFitToSection(value, type){
@@ -455,9 +463,9 @@
         * Anchors or index positions can be used as params.
         */
         function silentMoveTo(sectionAnchor, slideAnchor){
-            setScrollingSpeed (0, 'internal');
+            setTransitionSpeed (0, 'internal');
             moveTo(sectionAnchor, slideAnchor);
-            setScrollingSpeed (originals.scrollingSpeed, 'internal');
+            setTransitionSpeed (originals.transitionSpeed, 'internal');
         }
 
         /**
@@ -590,6 +598,7 @@
             FP.setAutoScrolling = setAutoScrolling;
             FP.setRecordHistory = setRecordHistory;
             FP.setScrollingSpeed = setScrollingSpeed;
+            FP.setTransitionSpeed = setTransitionSpeed;
             FP.setFitToSection = setFitToSection;
             FP.setLockAnchors = setLockAnchors;
             FP.setMouseWheelScrolling = setMouseWheelScrolling;
@@ -2705,7 +2714,7 @@
         * Adds transition animations for the given element
         */
         function addAnimation(element){
-            var transition = 'all ' + options.scrollingSpeed + 'ms ' + options.easingcss3;
+            var transition = 'all ' + options.transitionSpeed + 'ms ' + options.easingcss3;
 
             removeClass(element, NO_TRANSITION);
             return css(element, {

--- a/src/fullpage.js
+++ b/src/fullpage.js
@@ -121,8 +121,8 @@
 
             //scrolling
             css3: true,
-            transitionSpeed: this.scrollingSpeed,
             scrollingSpeed: 700,
+            transitionSpeed: this.scrollingSpeed,
             autoScrolling: true,
             fitToSection: true,
             fitToSectionDelay: 1000,


### PR DESCRIPTION
On my MacBook I tried to lower the scrollingSpeed, because i wanted the css transition from one section to the next to be faster (at around 250ms). The problem with this was, that with my MacBook (Chrome) the smooth scrolling takes longer than 250ms to come to rest. So then it scrolled over more than one section in one go and it's very difficult to scroll only to the next section.

So I tried to set a shorter transition time via css. But this doesn't work as you can't use silentMoveTo anymore, because the transition time is overriden.

So I came to the conclusion, that the scroll response wait time should be disconnected from the transition time. 

---

P.S. slightly offtopic: I think that 
```CSS
transition: all;
```
**all** is bad for performance, it should be only **transform**. But I don't know if that would break other extensions.