### PR TITLE
#3925 Vertical Center #fp-nav Using 2D Transform

### DIFF
--- a/src/fullpage.css
+++ b/src/fullpage.css
@@ -98,10 +98,11 @@ html.fp-enabled,
 #fp-nav {
     position: fixed;
     z-index: 100;
-    margin-top: -32px;
     top: 50%;
     opacity: 1;
-    -webkit-transform: translate3d(0,0,0);
+    transform: translateY(-50%);
+    -ms-transform: translateY(-50%);
+    -webkit-transform: translate3d(0,-50%,0);
 }
 #fp-nav.fp-right {
     right: 17px;

--- a/src/fullpage.js
+++ b/src/fullpage.js
@@ -1095,10 +1095,7 @@
                 li += '</li>';
             }
             $('ul', nav)[0].innerHTML = li;
-
-            //centering it vertically
-            css($(SECTION_NAV_SEL), {'margin-top': '-' + ($(SECTION_NAV_SEL)[0].offsetHeight/2) + 'px'});
-
+            
             //activating the current active section
 
             var bullet = $('li', $(SECTION_NAV_SEL)[0])[index($(SECTION_ACTIVE_SEL)[0], SECTION_SEL)];


### PR DESCRIPTION
#3925 Vertical Centering of #fp-nav was achieved by mixing css margin-top
and Javascript which applied directly to the element resulting in
having to use too much css overrides and !important when moving the
navigation with callbacks or styling the vertical navigation menu
