### PR TITLE
Fix for #3931 (normalScrollElements option)

### DIFF
--- a/vendors/scrolloverflow.js
+++ b/vendors/scrolloverflow.js
@@ -2406,7 +2406,7 @@ if ( typeof module != 'undefined' && module.exports ) {
 
             // Enables or disables the whole iScroll feature based on the given parameter.
             setIscroll: function(target, enable){
-                if(!iscrollHandler.hasBeenInit){
+                if(!iscrollHandler.hasBeenInit || !target){
                     return;
                 }
                 var scrollable = fp_utils.closest(target, SCROLLABLE_SEL) || $(SCROLLABLE_SEL, target)[0];


### PR DESCRIPTION
This is a fix for the issue #3931, that appears when **normalScrollElements** option is added and mouse cursor leaves from a browser window.

When the mouse cursor left the viewport, the **scrollable** variable was not assigned a value, because the **target** parameter, in this case, is null. So, I just added a check for the **target** parameter value in **2409** line.

