### PR TITLE
Update fullpage.js: Changed assignment of "slideMoving" in "moveSlide" function

### DIFF
--- a/src/fullpage.js
+++ b/src/fullpage.js
@@ -1624,7 +1624,7 @@
                 }
             }
 
-            slideMoving = true && !FP.test.isTesting;
+            slideMoving = !FP.test.isTesting;
             landscapeScroll(slides, destiny, direction);
         }
 


### PR DESCRIPTION
Hello,

In the `moveSlide` function, the following line occurs at the end:
`slideMoving = true && !FP.test.isTesting;`
I changed this to:
`slideMoving = !FP.test.isTesting;`

I did this because it is unnecessary to perform an AND-operation with true as the left operand as then the result of the assignment will always be the right operand. Therefore, the AND-operation can be removed.

I hope this is clear enough and look forward to your comments.

Kind regards,
Florian
