### PR TITLE
Fixed bug: #4480 scrolling up jumpy behaviour

### DIFF
--- a/src/js/beyondFullpage/beyondFullPageHandler.js
+++ b/src/js/beyondFullpage/beyondFullPageHandler.js
@@ -1,75 +1,35 @@
 import * as utils from '../common/utils.js';
-import { getState, setState } from "../common/state.js";
+import { getState } from "../common/state.js";
 import { setPrevTime } from '../common/tick.js';
 import { wheelDataHandler } from './wheelDataHandler.js';
-import { getScrollSettings } from '../common/utilsFP.js';
 import { scrollUpToFullpage } from './scrollBeyondFullPage.js';
 
 export function beyondFullPageHandler(container, e){
     var curTime = new Date().getTime();
-    var pauseScroll = getState().isBeyondFullpage && container.getBoundingClientRect().bottom >= 0 && wheelDataHandler.getDirection() === 'up';
     var g_isAboutToScrollToFullPage = getState().isAboutToScrollToFullPage;
+    // Register the event and get current mousewheel scrolling direction
+    wheelDataHandler.registerEvent(e);
+    var scrollWheelDirection = wheelDataHandler.getDirection();
 
-    if(g_isAboutToScrollToFullPage){
+    if (g_isAboutToScrollToFullPage) {
         setPrevTime(curTime);
         utils.preventDefault(e);
         return false;
     }
 
-    if(getState().isBeyondFullpage){
-        if(!pauseScroll){
-            keyframeTime('set', 'beyondFullpage', 1000);
+    if (getState().isBeyondFullpage) {
+        // If user is beyound the fullpage, let's check fullpage container position.
+        // The scrolling direction we already got by "getDirection".
+        var containerBounding = container.getBoundingClientRect();
+        if (containerBounding.bottom >= 0 && scrollWheelDirection === 'up') {
+            // move to the fullpage container only if user scrolls up and fullpage container is in the viewport
+            scrollUpToFullpage();
+            utils.preventDefault(e);
+            return false;
         }
-        else {
-            var shouldSetFixedPosition = !g_isAboutToScrollToFullPage && (!keyframeTime('isNewKeyframe', 'beyondFullpage') || !wheelDataHandler.isAccelerating() );
-            var scrollSettings;
-            if( shouldSetFixedPosition ){
-                scrollSettings = getScrollSettings(utils.getLast(getState().sections).item.offsetTop + utils.getLast(getState().sections).item.offsetHeight);
-                scrollSettings.element.scrollTo(0, scrollSettings.options);
-                setState({isAboutToScrollToFullPage: false});
-
-                utils.preventDefault(e);
-                return false;
-            }
-            else if( wheelDataHandler.isAccelerating() ){
-                pauseScroll = false;
-                setState({isAboutToScrollToFullPage: true});
-                setState({scrollTrigger: 'wheel'});
-
-                scrollUpToFullpage();
-                
-                utils.preventDefault(e);
-                return false;
-            }
-        }
-
-        if(!g_isAboutToScrollToFullPage){
-
+        if (!g_isAboutToScrollToFullPage) {
             // allow normal scrolling, but quitting
-            if(!pauseScroll){
-                return true;
-            }
+            return true;
         }   
     }
 }
-
-var keyframeTime = (function(){
-    let isNew = false;
-    var frames = {};
-    var timeframes = {};
-
-    return function(action, name, timeframe){
-        switch(action){
-            case 'set':
-                frames[name] = new Date().getTime();
-                timeframes[name] = timeframe;
-                break;
-            case 'isNewKeyframe':
-                const current = new Date().getTime();
-                isNew = current - frames[name] > timeframes[name];
-                break;
-        }
-
-        return isNew;
-    };
-})();


### PR DESCRIPTION
Hi there!
I faced the same bug as described in issue #4480.
I took the liberty and rewrote the function "beyondFullPageHandler". It looks cleaner now, and I decided to abandon the approach that allowed a user to return to the fullPage container (after normal scrolling) only by accelerating scrolling.

I tried to comment my code clearly but feel free to ask if something is not clear.

Now it scrolls smoothly without any struggle and jumping



https://user-images.githubusercontent.com/22250872/234598209-ec258b99-fdf4-4475-b607-1ccf2fb287ed.mp4

