### PR TITLE
Fix typo: throw->through

### DIFF
--- a/examples/navigation-vertical.html
+++ b/examples/navigation-vertical.html
@@ -125,7 +125,7 @@
 	<div class="section " id="section0">
 		<div class="intro">
 			<h1>Navigation dots</h1>
-			<p>An easy and beautiful way to navigate throw the sections</p>
+			<p>An easy and beautiful way to navigate through the sections</p>
 		</div>
 	</div>
 	<div class="section" id="section1">


### PR DESCRIPTION
Hi! Quick PR to swap 'throw' with 'through' for the description of vertical navigation:

![image](https://github.com/alvarotrigo/fullPage.js/assets/53410876/050990ff-3c3e-485b-b2dd-71ba42b3a095)

Including 'the' before 'sections' also isn't necessary, but I'd consider that a more stylistic choice.